### PR TITLE
Add jitter to HTTP polling transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2511,6 +2511,7 @@ dependencies = [
  "bincode",
  "futures",
  "percent-encoding",
+ "rand 0.9.2",
  "reme-message",
  "reqwest",
  "rustls",

--- a/crates/reme-transport/Cargo.toml
+++ b/crates/reme-transport/Cargo.toml
@@ -20,6 +20,7 @@ reqwest = { workspace = true, features = ["json", "rustls-tls"] }
 tokio = { workspace = true, features = ["full"] }
 tokio-util = { workspace = true }
 futures = { workspace = true }
+rand = { workspace = true }
 
 # TLS + Certificate Pinning
 rustls = { workspace = true, features = ["ring"] }

--- a/crates/reme-transport/src/receiver.rs
+++ b/crates/reme-transport/src/receiver.rs
@@ -7,9 +7,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use rand::Rng;
 use reme_message::RoutingKey;
 use tokio::sync::mpsc;
-use tokio::time::{interval, MissedTickBehavior};
+use tokio::time::{interval, sleep, MissedTickBehavior};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
 
@@ -21,12 +22,22 @@ use crate::{EventReceiver, EventSender, TransportEvent};
 pub struct ReceiverConfig {
     /// How often to poll for new messages
     pub poll_interval: Duration,
+    /// Whether to apply jitter to polling intervals
+    ///
+    /// When enabled, uses "equal jitter" strategy:
+    /// - actual_delay = poll_interval/2 + random(0, poll_interval/2)
+    /// - Result: delay between 50% and 100% of poll_interval
+    ///
+    /// This helps reduce load spikes and avoid thundering herd problems
+    /// when multiple clients poll simultaneously.
+    pub enable_jitter: bool,
 }
 
 impl Default for ReceiverConfig {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(5),
+            enable_jitter: false,
         }
     }
 }
@@ -34,7 +45,24 @@ impl Default for ReceiverConfig {
 impl ReceiverConfig {
     /// Create a config with a custom poll interval
     pub fn with_poll_interval(poll_interval: Duration) -> Self {
-        Self { poll_interval }
+        Self {
+            poll_interval,
+            enable_jitter: false,
+        }
+    }
+
+    /// Create a config with jitter enabled
+    pub fn with_jitter(poll_interval: Duration) -> Self {
+        Self {
+            poll_interval,
+            enable_jitter: true,
+        }
+    }
+
+    /// Enable or disable jitter on an existing config
+    pub fn set_jitter(mut self, enable: bool) -> Self {
+        self.enable_jitter = enable;
+        self
     }
 }
 
@@ -139,14 +167,30 @@ async fn polling_loop(
     tx: EventSender,
     cancel_token: CancellationToken,
 ) {
+    debug!(
+        "Started message polling for routing key {:?} (interval: {:?}, jitter: {})",
+        &routing_key[..4],
+        config.poll_interval,
+        config.enable_jitter
+    );
+
+    if config.enable_jitter {
+        polling_loop_with_jitter(transport, routing_key, config, tx, cancel_token).await;
+    } else {
+        polling_loop_fixed(transport, routing_key, config, tx, cancel_token).await;
+    }
+}
+
+/// Polling loop with fixed interval (no jitter)
+async fn polling_loop_fixed(
+    transport: Arc<HttpTransport>,
+    routing_key: RoutingKey,
+    config: ReceiverConfig,
+    tx: EventSender,
+    cancel_token: CancellationToken,
+) {
     let mut poll_interval = interval(config.poll_interval);
     poll_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
-
-    debug!(
-        "Started message polling for routing key {:?} (interval: {:?})",
-        &routing_key[..4],
-        config.poll_interval
-    );
 
     loop {
         tokio::select! {
@@ -155,30 +199,83 @@ async fn polling_loop(
                 break;
             }
             _ = poll_interval.tick() => {
-                match transport.fetch_once(&routing_key).await {
-                    Ok(messages) => {
-                        if !messages.is_empty() {
-                            debug!(
-                                "Fetched {} messages for {:?}",
-                                messages.len(), &routing_key[..4]
-                            );
-                        }
+                fetch_and_send(&transport, &routing_key, &tx).await;
+            }
+        }
+    }
+}
 
-                        for envelope in messages {
-                            if tx.send(TransportEvent::Message(envelope)).is_err() {
-                                debug!("Channel closed, stopping polling");
-                                return;
-                            }
-                        }
+/// Polling loop with jitter applied
+///
+/// Uses "equal jitter" strategy: delay = base/2 + random(0, base/2)
+/// This provides delays between 50% and 100% of the base interval.
+async fn polling_loop_with_jitter(
+    transport: Arc<HttpTransport>,
+    routing_key: RoutingKey,
+    config: ReceiverConfig,
+    tx: EventSender,
+    cancel_token: CancellationToken,
+) {
+    let base_millis = config.poll_interval.as_millis() as u64;
+    let half_base = base_millis / 2;
+
+    loop {
+        tokio::select! {
+            _ = cancel_token.cancelled() => {
+                debug!("Message polling cancelled for routing key {:?}", &routing_key[..4]);
+                break;
+            }
+            else => {
+                fetch_and_send(&transport, &routing_key, &tx).await;
+
+                // Calculate next delay with jitter: half_base + random(0, half_base)
+                let jitter_millis = rand::rng().random_range(0..=half_base);
+                let delay_millis = half_base + jitter_millis;
+                let delay = Duration::from_millis(delay_millis);
+
+                // Wait for the jittered delay or cancellation
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        debug!("Message polling cancelled for routing key {:?}", &routing_key[..4]);
+                        break;
                     }
-                    Err(e) => {
-                        warn!("Error fetching messages: {}", e);
-                        if tx.send(TransportEvent::Error(e.to_string())).is_err() {
-                            debug!("Channel closed, stopping polling");
-                            return;
-                        }
+                    _ = sleep(delay) => {
+                        // Continue to next iteration
                     }
                 }
+            }
+        }
+    }
+}
+
+/// Fetch messages and send them to the channel
+async fn fetch_and_send(
+    transport: &Arc<HttpTransport>,
+    routing_key: &RoutingKey,
+    tx: &EventSender,
+) {
+    match transport.fetch_once(routing_key).await {
+        Ok(messages) => {
+            if !messages.is_empty() {
+                debug!(
+                    "Fetched {} messages for {:?}",
+                    messages.len(),
+                    &routing_key[..4]
+                );
+            }
+
+            for envelope in messages {
+                if tx.send(TransportEvent::Message(envelope)).is_err() {
+                    debug!("Channel closed, stopping polling");
+                    return;
+                }
+            }
+        }
+        Err(e) => {
+            warn!("Error fetching messages: {}", e);
+            if tx.send(TransportEvent::Error(e.to_string())).is_err() {
+                debug!("Channel closed, stopping polling");
+                return;
             }
         }
     }
@@ -192,11 +289,31 @@ mod tests {
     fn test_default_config() {
         let config = ReceiverConfig::default();
         assert_eq!(config.poll_interval, Duration::from_secs(5));
+        assert_eq!(config.enable_jitter, false);
     }
 
     #[test]
     fn test_custom_poll_interval() {
         let config = ReceiverConfig::with_poll_interval(Duration::from_secs(1));
         assert_eq!(config.poll_interval, Duration::from_secs(1));
+        assert_eq!(config.enable_jitter, false);
+    }
+
+    #[test]
+    fn test_with_jitter() {
+        let config = ReceiverConfig::with_jitter(Duration::from_secs(10));
+        assert_eq!(config.poll_interval, Duration::from_secs(10));
+        assert_eq!(config.enable_jitter, true);
+    }
+
+    #[test]
+    fn test_set_jitter() {
+        let config = ReceiverConfig::default()
+            .set_jitter(true);
+        assert_eq!(config.enable_jitter, true);
+
+        let config = ReceiverConfig::with_jitter(Duration::from_secs(5))
+            .set_jitter(false);
+        assert_eq!(config.enable_jitter, false);
     }
 }


### PR DESCRIPTION
Add configurable jitter to HTTP transport polling to reduce load spikes and avoid thundering herd problems when multiple clients poll simultaneously.

Features:
- Add enable_jitter flag to ReceiverConfig (default: false for backward compatibility)
- Implement "equal jitter" strategy: delay = base/2 + random(0, base/2)
- Add ReceiverConfig::with_jitter() constructor for easy jitter setup
- Add ReceiverConfig::set_jitter() method for toggling jitter on existing configs
- Refactor polling loop into separate fixed and jittered implementations

Implementation details:
- When jitter is enabled, polling delay varies between 50% and 100% of poll_interval
- Uses rand::rng() with random_range() for generating jitter values
- Maintains fixed interval behavior when jitter is disabled (no breaking changes)
- Both polling modes properly handle cancellation tokens

Tests:
- Add test coverage for jitter configuration methods
- Verify default behavior (no jitter) for backward compatibility
- All existing tests pass without modification

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable jitter to HTTP polling to smooth load and prevent thundering herd when many clients poll at once. Jitter is off by default for full backward compatibility.

- **New Features**
  - ReceiverConfig.enable_jitter flag (default: false)
  - Equal jitter: delay = base/2 + random(0, base/2) → 50–100% of poll_interval
  - ReceiverConfig::with_jitter(...) and .set_jitter(enable) helpers

- **Refactors**
  - Split polling into fixed and jittered loops; both honor cancellation
  - Extracted fetch_and_send helper for reuse

<sup>Written for commit 190f3e98f5abdeaab82d2a659e3209fd13930828. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable jitter support for receiver message polling intervals with new configuration methods to customize jitter behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->