### PR TITLE
refactor(message): extract WirePayload into separate wire module

### DIFF
--- a/crates/reme-message/src/lib.rs
+++ b/crates/reme-message/src/lib.rs
@@ -6,6 +6,7 @@ use uuid::Uuid;
 
 pub mod dag;
 pub mod tombstone;
+pub mod wire;
 
 pub use dag::{ConversationDag, GapResult, ReceiverGapDetector, SenderGapDetector};
 
@@ -60,11 +61,10 @@ pub fn bincode_config() -> impl bincode::config::Config {
 pub use tombstone::{
     // Tombstone V2 (signed ack)
     Attribution, SignedAckTombstone,
-    // Wire format
-    WirePayload, WireType,
     // Constants
     ACK_HASH_DOMAIN, CLOCK_SKEW_ALLOWANCE_HOURS, TOMBSTONE_MAX_AGE_HOURS,
 };
+pub use wire::{WirePayload, WireType};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct MessageID(Uuid);

--- a/crates/reme-message/src/tombstone.rs
+++ b/crates/reme-message/src/tombstone.rs
@@ -16,7 +16,8 @@
 //! - **Privacy**: No identity in wire format (nodes don't know sender/recipient)
 //! - **Replay prevention**: message_id binding in ack_secret derivation
 
-use crate::{MessageID, RoutingKey};
+use crate::wire::WireType;
+use crate::MessageID;
 use bincode::{Decode, Encode};
 use subtle::ConstantTimeEq;
 use xeddsa::{xed25519, Sign, Verify};
@@ -178,98 +179,6 @@ impl SignedAckTombstone {
     }
 }
 
-/// Wire payload type discriminator
-#[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WireType {
-    Message = 0x00,
-    /// Tombstone V2: Signed Ack (96 bytes)
-    AckTombstone = 0x02,
-}
-
-impl TryFrom<u8> for WireType {
-    type Error = String;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0x00 => Ok(WireType::Message),
-            0x02 => Ok(WireType::AckTombstone),
-            _ => Err(format!("Unknown wire type: 0x{:02x}", value)),
-        }
-    }
-}
-
-use crate::OuterEnvelope;
-
-/// Unified wire payload for messages and tombstones
-///
-/// Wire format: `[type: u8][payload: bincode bytes]`
-/// - type 0x00: Message (OuterEnvelope)
-/// - type 0x02: AckTombstone (SignedAckTombstone)
-#[derive(Debug, Clone)]
-pub enum WirePayload {
-    Message(OuterEnvelope),
-    /// Tombstone V2: Signed Ack
-    AckTombstone(SignedAckTombstone),
-}
-
-impl WirePayload {
-    /// Decode wire payload from bytes
-    pub fn decode(bytes: &[u8]) -> Result<Self, String> {
-        if bytes.is_empty() {
-            return Err("Empty payload".to_string());
-        }
-
-        let wire_type = WireType::try_from(bytes[0])?;
-
-        match wire_type {
-            WireType::Message => {
-                let (envelope, _): (OuterEnvelope, _) =
-                    bincode::decode_from_slice(&bytes[1..], bincode::config::standard())
-                        .map_err(|e| format!("Invalid message: {}", e))?;
-                Ok(WirePayload::Message(envelope))
-            }
-            WireType::AckTombstone => {
-                let (tombstone, _): (SignedAckTombstone, _) =
-                    bincode::decode_from_slice(&bytes[1..], bincode::config::standard())
-                        .map_err(|e| format!("Invalid ack tombstone: {}", e))?;
-                Ok(WirePayload::AckTombstone(tombstone))
-            }
-        }
-    }
-
-    /// Encode wire payload to bytes
-    pub fn encode(&self) -> Vec<u8> {
-        match self {
-            WirePayload::Message(envelope) => {
-                let mut bytes = vec![WireType::Message as u8];
-                bytes.extend(bincode::encode_to_vec(envelope, bincode::config::standard()).unwrap());
-                bytes
-            }
-            WirePayload::AckTombstone(tombstone) => {
-                let mut bytes = vec![WireType::AckTombstone as u8];
-                bytes.extend(bincode::encode_to_vec(tombstone, bincode::config::standard()).unwrap());
-                bytes
-            }
-        }
-    }
-
-    /// Get the routing key for this payload (only for Message)
-    pub fn routing_key(&self) -> Option<&RoutingKey> {
-        match self {
-            WirePayload::Message(envelope) => Some(&envelope.routing_key),
-            WirePayload::AckTombstone(_) => None, // V2 tombstones don't have routing_key
-        }
-    }
-
-    /// Get the message_id for this payload
-    pub fn message_id(&self) -> &MessageID {
-        match self {
-            WirePayload::Message(envelope) => &envelope.message_id,
-            WirePayload::AckTombstone(tombstone) => &tombstone.message_id,
-        }
-    }
-}
 
 #[cfg(test)]
 mod tests {
@@ -427,32 +336,4 @@ mod tests {
         assert_eq!(bytes.len(), 96, "SignedAckTombstone should be exactly 96 bytes");
     }
 
-    #[test]
-    fn test_ack_tombstone_wire_payload_roundtrip() {
-        let (_, priv_key) = generate_test_keypair();
-        let message_id = MessageID::new();
-        let ack_secret: [u8; 16] = [0x42; 16];
-
-        let tombstone = SignedAckTombstone::new(message_id, ack_secret, &priv_key);
-        let payload = WirePayload::AckTombstone(tombstone.clone());
-
-        let bytes = payload.encode();
-        let decoded = WirePayload::decode(&bytes).unwrap();
-
-        match decoded {
-            WirePayload::AckTombstone(restored) => {
-                assert_eq!(restored.message_id, tombstone.message_id);
-                assert_eq!(restored.ack_secret, tombstone.ack_secret);
-            }
-            _ => panic!("Expected AckTombstone"),
-        }
-    }
-
-    #[test]
-    fn test_wire_type_conversion() {
-        assert_eq!(WireType::try_from(0x00).unwrap(), WireType::Message);
-        assert_eq!(WireType::try_from(0x02).unwrap(), WireType::AckTombstone);
-        assert!(WireType::try_from(0x01).is_err()); // V1 tombstone type no longer supported
-        assert!(WireType::try_from(0x03).is_err());
-    }
 }

--- a/crates/reme-message/src/wire.rs
+++ b/crates/reme-message/src/wire.rs
@@ -1,0 +1,154 @@
+//! Wire format types for network transmission
+//!
+//! This module defines the unified wire format for messages and tombstones.
+//! All payloads are prefixed with a 1-byte type discriminator to enable
+//! multiplexing on the same transport.
+//!
+//! # Wire Format
+//!
+//! ```text
+//! [type: u8][payload: bincode bytes]
+//! ```
+//!
+//! Type discriminators:
+//! - `0x00`: Message (OuterEnvelope)
+//! - `0x02`: AckTombstone (SignedAckTombstone)
+
+use crate::tombstone::SignedAckTombstone;
+use crate::{MessageID, OuterEnvelope, RoutingKey};
+
+/// Wire payload type discriminator
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WireType {
+    Message = 0x00,
+    /// Tombstone V2: Signed Ack (96 bytes)
+    AckTombstone = 0x02,
+}
+
+impl TryFrom<u8> for WireType {
+    type Error = String;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x00 => Ok(WireType::Message),
+            0x02 => Ok(WireType::AckTombstone),
+            _ => Err(format!("Unknown wire type: 0x{:02x}", value)),
+        }
+    }
+}
+
+/// Unified wire payload for messages and tombstones
+///
+/// Wire format: `[type: u8][payload: bincode bytes]`
+/// - type 0x00: Message (OuterEnvelope)
+/// - type 0x02: AckTombstone (SignedAckTombstone)
+#[derive(Debug, Clone)]
+pub enum WirePayload {
+    Message(OuterEnvelope),
+    /// Tombstone V2: Signed Ack
+    AckTombstone(SignedAckTombstone),
+}
+
+impl WirePayload {
+    /// Decode wire payload from bytes
+    pub fn decode(bytes: &[u8]) -> Result<Self, String> {
+        if bytes.is_empty() {
+            return Err("Empty payload".to_string());
+        }
+
+        let wire_type = WireType::try_from(bytes[0])?;
+
+        match wire_type {
+            WireType::Message => {
+                let (envelope, _): (OuterEnvelope, _) =
+                    bincode::decode_from_slice(&bytes[1..], bincode::config::standard())
+                        .map_err(|e| format!("Invalid message: {}", e))?;
+                Ok(WirePayload::Message(envelope))
+            }
+            WireType::AckTombstone => {
+                let (tombstone, _): (SignedAckTombstone, _) =
+                    bincode::decode_from_slice(&bytes[1..], bincode::config::standard())
+                        .map_err(|e| format!("Invalid ack tombstone: {}", e))?;
+                Ok(WirePayload::AckTombstone(tombstone))
+            }
+        }
+    }
+
+    /// Encode wire payload to bytes
+    pub fn encode(&self) -> Vec<u8> {
+        match self {
+            WirePayload::Message(envelope) => {
+                let mut bytes = vec![WireType::Message as u8];
+                bytes.extend(bincode::encode_to_vec(envelope, bincode::config::standard()).unwrap());
+                bytes
+            }
+            WirePayload::AckTombstone(tombstone) => {
+                let mut bytes = vec![WireType::AckTombstone as u8];
+                bytes.extend(bincode::encode_to_vec(tombstone, bincode::config::standard()).unwrap());
+                bytes
+            }
+        }
+    }
+
+    /// Get the routing key for this payload (only for Message)
+    pub fn routing_key(&self) -> Option<&RoutingKey> {
+        match self {
+            WirePayload::Message(envelope) => Some(&envelope.routing_key),
+            WirePayload::AckTombstone(_) => None, // V2 tombstones don't have routing_key
+        }
+    }
+
+    /// Get the message_id for this payload
+    pub fn message_id(&self) -> &MessageID {
+        match self {
+            WirePayload::Message(envelope) => &envelope.message_id,
+            WirePayload::AckTombstone(tombstone) => &tombstone.message_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::RngCore;
+    use x25519_dalek::{PublicKey, StaticSecret};
+
+    /// Generate an X25519 keypair for testing
+    fn generate_test_keypair() -> ([u8; 32], [u8; 32]) {
+        let mut secret = [0u8; 32];
+        rand::rng().fill_bytes(&mut secret);
+        let static_secret = StaticSecret::from(secret);
+        let public = PublicKey::from(&static_secret);
+        (*public.as_bytes(), secret)
+    }
+
+    #[test]
+    fn test_wire_type_conversion() {
+        assert_eq!(WireType::try_from(0x00).unwrap(), WireType::Message);
+        assert_eq!(WireType::try_from(0x02).unwrap(), WireType::AckTombstone);
+        assert!(WireType::try_from(0x01).is_err()); // V1 tombstone type no longer supported
+        assert!(WireType::try_from(0x03).is_err());
+    }
+
+    #[test]
+    fn test_ack_tombstone_wire_payload_roundtrip() {
+        let (_, priv_key) = generate_test_keypair();
+        let message_id = MessageID::new();
+        let ack_secret: [u8; 16] = [0x42; 16];
+
+        let tombstone = SignedAckTombstone::new(message_id, ack_secret, &priv_key);
+        let payload = WirePayload::AckTombstone(tombstone.clone());
+
+        let bytes = payload.encode();
+        let decoded = WirePayload::decode(&bytes).unwrap();
+
+        match decoded {
+            WirePayload::AckTombstone(restored) => {
+                assert_eq!(restored.message_id, tombstone.message_id);
+                assert_eq!(restored.ack_secret, tombstone.ack_secret);
+            }
+            _ => panic!("Expected AckTombstone"),
+        }
+    }
+}


### PR DESCRIPTION
Move WireType and WirePayload from tombstone.rs to new wire.rs module. These types handle wire format discrimination for all payload types (messages and tombstones), not just tombstones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted WireType and WirePayload into a new wire module to centralize wire format handling for messages and tombstones. This cleans up tombstone.rs and makes the wire layer reusable without changing behavior.

- **Refactors**
  - Added wire.rs with WireType and WirePayload (encode/decode, routing_key, message_id).
  - Removed these types from tombstone.rs; updated imports and re-exported from lib.rs for compatibility.
  - Moved related tests to wire.rs.

<sup>Written for commit cd55a218332c417b1321a684862fd97ea7648aaf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized wire format handling into a dedicated module for improved code organization. The `WireType` and `WirePayload` types are now exported from the wire module instead of the tombstone module. Core functionality remains unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->