### PR TITLE
refactor: add strum derives for enum utilities (Display, EnumIter, FromRepr)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2494,6 +2494,7 @@ dependencies = [
  "rand 0.9.2",
  "rand_core 0.6.4",
  "reme-identity",
+ "strum 0.27.2",
  "subtle",
  "uuid",
  "x25519-dalek",
@@ -2521,6 +2522,7 @@ dependencies = [
  "reme-identity",
  "reme-message",
  "reme-transport",
+ "strum 0.27.2",
  "thiserror 2.0.17",
  "tokio",
 ]
@@ -2559,6 +2561,7 @@ dependencies = [
  "rustls 0.23.35",
  "serde",
  "sha2",
+ "strum 0.27.2",
  "thiserror 2.0.17",
  "tokio",
  "tokio-util",

--- a/crates/reme-message/Cargo.toml
+++ b/crates/reme-message/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 reme-identity = { workspace = true }
 
 bincode = { workspace = true }
+strum = { workspace = true, features = ["derive"] }
 uuid = { workspace = true, features = ["v4"] }
 
 # Tombstone crypto

--- a/crates/reme-message/src/tombstone.rs
+++ b/crates/reme-message/src/tombstone.rs
@@ -16,6 +16,8 @@
 //! - **Privacy**: No identity in wire format (nodes don't know sender/recipient)
 //! - **Replay prevention**: message_id binding in ack_secret derivation
 
+use strum::{Display, EnumIter};
+
 use crate::wire::WireType;
 use crate::MessageID;
 use bincode::{Decode, Encode};
@@ -73,7 +75,7 @@ pub struct SignedAckTombstone {
 }
 
 /// Who created a tombstone (for delivery confirmation)
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter)]
 pub enum Attribution {
     /// Tombstone was signed by the message sender
     Sender,

--- a/crates/reme-message/src/wire.rs
+++ b/crates/reme-message/src/wire.rs
@@ -14,28 +14,18 @@
 //! - `0x00`: Message (OuterEnvelope)
 //! - `0x02`: AckTombstone (SignedAckTombstone)
 
+use strum::FromRepr;
+
 use crate::tombstone::SignedAckTombstone;
 use crate::{MessageID, OuterEnvelope, RoutingKey};
 
 /// Wire payload type discriminator
 #[repr(u8)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, FromRepr)]
 pub enum WireType {
     Message = 0x00,
     /// Tombstone V2: Signed Ack (96 bytes)
     AckTombstone = 0x02,
-}
-
-impl TryFrom<u8> for WireType {
-    type Error = String;
-
-    fn try_from(value: u8) -> Result<Self, Self::Error> {
-        match value {
-            0x00 => Ok(WireType::Message),
-            0x02 => Ok(WireType::AckTombstone),
-            _ => Err(format!("Unknown wire type: 0x{:02x}", value)),
-        }
-    }
 }
 
 /// Unified wire payload for messages and tombstones
@@ -57,7 +47,8 @@ impl WirePayload {
             return Err("Empty payload".to_string());
         }
 
-        let wire_type = WireType::try_from(bytes[0])?;
+        let wire_type = WireType::from_repr(bytes[0])
+            .ok_or_else(|| format!("Unknown wire type: 0x{:02x}", bytes[0]))?;
 
         match wire_type {
             WireType::Message => {
@@ -125,10 +116,10 @@ mod tests {
 
     #[test]
     fn test_wire_type_conversion() {
-        assert_eq!(WireType::try_from(0x00).unwrap(), WireType::Message);
-        assert_eq!(WireType::try_from(0x02).unwrap(), WireType::AckTombstone);
-        assert!(WireType::try_from(0x01).is_err()); // V1 tombstone type no longer supported
-        assert!(WireType::try_from(0x03).is_err());
+        assert_eq!(WireType::from_repr(0x00), Some(WireType::Message));
+        assert_eq!(WireType::from_repr(0x02), Some(WireType::AckTombstone));
+        assert_eq!(WireType::from_repr(0x01), None); // V1 tombstone type no longer supported
+        assert_eq!(WireType::from_repr(0x03), None);
     }
 
     #[test]

--- a/crates/reme-outbox/Cargo.toml
+++ b/crates/reme-outbox/Cargo.toml
@@ -9,6 +9,7 @@ reme-identity = { workspace = true }
 reme-message = { workspace = true }
 reme-transport = { workspace = true }
 
+strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 bincode = { workspace = true }
 

--- a/crates/reme-outbox/src/state.rs
+++ b/crates/reme-outbox/src/state.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashSet;
 
+use strum::{Display, EnumIter};
+
 use reme_identity::PublicID;
 use reme_message::{ContentId, MessageID};
 
@@ -170,7 +172,7 @@ pub enum DeliveryConfirmation {
 /// Derived delivery state for UI and logic.
 ///
 /// Computed from attempt history and confirmation status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display, EnumIter)]
 pub enum DeliveryState {
     /// No attempts yet, waiting for first send
     Pending,

--- a/crates/reme-transport/Cargo.toml
+++ b/crates/reme-transport/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 reme-message = { workspace = true }
 reme-node-core = { workspace = true, optional = true }
 
+strum = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 bincode = { workspace = true }

--- a/crates/reme-transport/src/delivery.rs
+++ b/crates/reme-transport/src/delivery.rs
@@ -7,6 +7,8 @@
 
 use std::time::Duration;
 
+use strum::{Display, EnumIter};
+
 use crate::target::TargetId;
 use crate::TransportError;
 
@@ -35,7 +37,7 @@ impl std::fmt::Display for QuorumStrategyError {
 impl std::error::Error for QuorumStrategyError {}
 
 /// Delivery tiers in priority order.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Display, EnumIter)]
 pub enum DeliveryTier {
     /// Direct delivery to recipient or their peer (mDNS, DHT, Iroh).
     /// Highest priority - if successful, recipient has the message.

--- a/crates/reme-transport/src/target.rs
+++ b/crates/reme-transport/src/target.rs
@@ -10,6 +10,7 @@ use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use reme_message::{OuterEnvelope, SignedAckTombstone};
+use strum::{Display, EnumIter};
 
 use crate::url_auth::sanitize_url_for_logging;
 use crate::TransportError;
@@ -58,7 +59,7 @@ impl std::fmt::Display for TargetId {
 /// Binary classification of transport targets.
 ///
 /// This simple classification drives default retry behavior and routing priority.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Display, EnumIter)]
 pub enum TargetKind {
     /// Stable targets: mailbox nodes, manually configured peers, MQTT brokers.
     ///
@@ -125,7 +126,7 @@ impl TargetKind {
 }
 
 /// Health state for circuit breaker pattern.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Display, EnumIter)]
 pub enum HealthState {
     /// Target is healthy, normal operation.
     #[default]


### PR DESCRIPTION
- WireType: Use strum::FromRepr to replace manual TryFrom<u8> impl
- Attribution: Add Display, EnumIter for logging/UI
- TargetKind: Add Display, EnumIter for logging/filtering
- HealthState: Add Display, EnumIter for status displays
- DeliveryTier: Add Display, EnumIter for tier configuration
- DeliveryState: Add Display, EnumIter for UI state displays

This eliminates manual boilerplate while enabling:
- Automatic Display formatting for logs
- Iterator access over enum variants via EnumIter
- Type-safe repr(u8) conversion via FromRepr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored enums to use strum derives (Display, EnumIter, FromRepr) and switched WireType parsing to FromRepr for safer repr(u8) conversion. This reduces boilerplate and improves logging and UI rendering.

- **Refactors**
  - WireType: replaced manual TryFrom<u8> with strum::FromRepr and updated decoding/tests.
  - Added Display, EnumIter to Attribution, TargetKind, HealthState, DeliveryTier, DeliveryState for logging, filtering, and UI.

- **Dependencies**
  - Added strum (derive feature) to reme-message, reme-outbox, and reme-transport.

<sup>Written for commit 1333e761d1b71ce2d7c08776ddfe1c910d067bf3. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified enum implementations across internal modules by replacing manual trait implementations with derived traits, improving code maintainability and consistency.

* **Chores**
  * Added strum library dependency to support enhanced enum capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->