### PR TITLE
Fix: Apply HTTP Basic Auth from config with correct precedence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +162,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -770,6 +789,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1348,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1936,6 +1979,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2432,6 +2485,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "reme-config"
 version = "0.1.0"
 dependencies = [
@@ -2589,6 +2671,7 @@ dependencies = [
  "rumqttc",
  "rustls 0.23.35",
  "serde",
+ "serde_json",
  "sha2",
  "strum 0.27.2",
  "thiserror 2.0.17",
@@ -2599,6 +2682,7 @@ dependencies = [
  "url",
  "uuid",
  "webpki-roots",
+ "wiremock",
  "x509-parser",
 ]
 
@@ -4142,6 +4226,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -426,6 +426,11 @@ impl App<'_> {
                 // Set node pubkey if present
                 config = config.with_node_pubkey_opt(parsed_peer.node_pubkey);
 
+                // Set HTTP Basic Auth if configured
+                if let Some((username, password)) = &parsed_peer.auth {
+                    config = config.with_auth(username, password);
+                }
+
                 // Create target and add to pool
                 let target = HttpTarget::new(config)?;
                 pool.add_target(target);

--- a/crates/reme-transport/Cargo.toml
+++ b/crates/reme-transport/Cargo.toml
@@ -62,3 +62,5 @@ tokio = { workspace = true, features = ["test-util", "macros"] }
 reme-encryption = { workspace = true }
 axum = { workspace = true }
 rand = { workspace = true }
+wiremock = "0.6"
+serde_json = "1"

--- a/crates/reme-transport/src/http_target.rs
+++ b/crates/reme-transport/src/http_target.rs
@@ -34,6 +34,11 @@ pub struct HttpTargetConfig {
 
     /// Optional certificate pin for TLS verification.
     pub cert_pin: Option<CertPin>,
+
+    /// Explicit HTTP Basic Auth credentials (username, password).
+    ///
+    /// Takes precedence over URL-embedded credentials.
+    pub auth: Option<(String, String)>,
 }
 
 impl HttpTargetConfig {
@@ -45,6 +50,7 @@ impl HttpTargetConfig {
             base: TargetConfig::new(id, kind),
             url,
             cert_pin: None,
+            auth: None,
         }
     }
 
@@ -61,6 +67,14 @@ impl HttpTargetConfig {
     /// Set the certificate pin for TLS verification.
     pub fn with_cert_pin(mut self, pin: CertPin) -> Self {
         self.cert_pin = Some(pin);
+        self
+    }
+
+    /// Set explicit HTTP Basic Auth credentials.
+    ///
+    /// Takes precedence over URL-embedded credentials.
+    pub fn with_auth(mut self, username: impl Into<String>, password: impl Into<String>) -> Self {
+        self.auth = Some((username.into(), password.into()));
         self
     }
 
@@ -123,6 +137,10 @@ pub struct HttpTarget {
     config: HttpTargetConfig,
     client: Client,
     health: TargetHealth,
+    /// Sanitized URL (credentials removed, parsed once in constructor).
+    sanitized_url: String,
+    /// URL-embedded auth credentials (parsed once in constructor).
+    url_auth: Option<(String, String)>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -182,6 +200,10 @@ impl HttpTarget {
     /// - Request timeout from config
     /// - Connect timeout from config
     pub fn new(config: HttpTargetConfig) -> Result<Self, TransportError> {
+        // Parse URL once to extract credentials and sanitized URL
+        let parsed = parse_url_with_auth(&config.url)
+            .map_err(|e| TransportError::Network(format!("Invalid URL: {e}")))?;
+
         let client = build_target_client(&config)?;
         let health = TargetHealth::new(
             config.base.circuit_breaker_threshold,
@@ -192,6 +214,8 @@ impl HttpTarget {
             config,
             client,
             health,
+            sanitized_url: parsed.url,
+            url_auth: parsed.auth,
         })
     }
 
@@ -209,11 +233,7 @@ impl HttpTarget {
     ///
     /// Returns the raw receipt data from the node (if any).
     async fn submit_payload(&self, payload_b64: &str) -> Result<RawReceipt, TransportError> {
-        // Parse URL and extract credentials if present
-        let parsed = parse_url_with_auth(&self.config.url)
-            .map_err(|e| TransportError::Network(format!("Invalid URL: {e}")))?;
-
-        let url = format!("{}/api/v1/submit", parsed.url.trim_end_matches('/'));
+        let url = format!("{}/api/v1/submit", self.sanitized_url.trim_end_matches('/'));
 
         let mut request = self
             .client
@@ -222,8 +242,10 @@ impl HttpTarget {
             .timeout(self.config.base.request_timeout)
             .body(payload_b64.to_string());
 
-        // Add Basic Auth if credentials were embedded in URL
-        if let Some((username, password)) = parsed.auth {
+        // Priority 1: Explicit auth from config
+        // Priority 2: URL-embedded auth (legacy/backward compat)
+        let auth = self.config.auth.as_ref().or(self.url_auth.as_ref());
+        if let Some((username, password)) = auth {
             request = request.basic_auth(username, Some(password));
         }
 
@@ -304,13 +326,9 @@ impl HttpTarget {
         &self,
         routing_key_b64: &str,
     ) -> Result<Vec<OuterEnvelope>, TransportError> {
-        // Parse URL and extract credentials if present
-        let parsed = parse_url_with_auth(&self.config.url)
-            .map_err(|e| TransportError::Network(format!("Invalid URL: {e}")))?;
-
         let url = format!(
             "{}/api/v1/fetch/{}",
-            parsed.url.trim_end_matches('/'),
+            self.sanitized_url.trim_end_matches('/'),
             routing_key_b64
         );
 
@@ -319,8 +337,10 @@ impl HttpTarget {
             .get(&url)
             .timeout(self.config.base.request_timeout);
 
-        // Add Basic Auth if credentials were embedded in URL
-        if let Some((username, password)) = parsed.auth {
+        // Priority 1: Explicit auth from config
+        // Priority 2: URL-embedded auth (legacy/backward compat)
+        let auth = self.config.auth.as_ref().or(self.url_auth.as_ref());
+        if let Some((username, password)) = auth {
             request = request.basic_auth(username, Some(password));
         }
 

--- a/crates/reme-transport/tests/http_auth_test.rs
+++ b/crates/reme-transport/tests/http_auth_test.rs
@@ -1,0 +1,223 @@
+//! Integration tests for HTTP authentication precedence.
+//!
+//! Tests verify:
+//! 1. Explicit auth (config) is applied correctly
+//! 2. URL-embedded auth still works (backward compatibility)
+//! 3. Explicit auth takes precedence over URL-embedded auth
+//! 4. No auth = no Authorization header
+
+use reme_identity::Identity;
+use reme_message::{MessageID, OuterEnvelope, SignedAckTombstone};
+use reme_transport::http_target::{HttpTarget, HttpTargetConfig};
+use reme_transport::target::TargetKind;
+use reme_transport::target::TransportTarget;
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Match, Request};
+
+/// Custom matcher that verifies Authorization header is NOT present.
+struct NoAuthHeader;
+
+impl Match for NoAuthHeader {
+    fn matches(&self, request: &Request) -> bool {
+        !request.headers.contains_key("authorization")
+    }
+}
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Build a minimal test `OuterEnvelope` for submission.
+///
+/// We don't need real encryption for auth tests, just a valid wire format.
+fn build_test_envelope() -> OuterEnvelope {
+    let bob = Identity::generate();
+    let routing_key = bob.public_id().routing_key();
+
+    // Build minimal OuterEnvelope (no actual encryption needed for auth tests)
+    OuterEnvelope::new(
+        routing_key,
+        None,           // No TTL
+        [0u8; 32],      // Dummy ephemeral key
+        [0u8; 16],      // Dummy ack_hash
+        vec![0u8; 100], // Dummy ciphertext
+    )
+}
+
+/// Build a test `SignedAckTombstone` for submission.
+fn build_test_tombstone() -> SignedAckTombstone {
+    let alice = Identity::generate();
+    let message_id = MessageID::new();
+    let ack_secret = [42u8; 16];
+
+    SignedAckTombstone::new(message_id, ack_secret, &alice.x25519_secret().to_bytes())
+}
+
+#[tokio::test]
+async fn test_explicit_auth_applied() {
+    // Start mock server expecting specific Basic Auth
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/submit"))
+        .and(header(
+            "Authorization",
+            "Basic dXNlcjpwYXNzd29yZA==", // base64("user:password")
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Create HttpTarget with explicit auth
+    let config =
+        HttpTargetConfig::new(mock_server.uri(), TargetKind::Stable).with_auth("user", "password");
+
+    let target = HttpTarget::new(config).expect("Failed to create HttpTarget");
+
+    // Submit envelope
+    let envelope = build_test_envelope();
+    let result = target.submit_message(envelope).await;
+
+    assert!(
+        result.is_ok(),
+        "Explicit auth should be applied: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_url_embedded_auth_works() {
+    // Start mock server expecting URL-embedded auth
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/submit"))
+        .and(header(
+            "Authorization",
+            "Basic dXJsX3VzZXI6dXJsX3Bhc3M=", // base64("url_user:url_pass")
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Create HttpTarget with URL-embedded auth
+    let url_with_auth = format!("http://url_user:url_pass@{}", mock_server.address());
+    let config = HttpTargetConfig::new(url_with_auth, TargetKind::Stable);
+
+    let target = HttpTarget::new(config).expect("Failed to create HttpTarget");
+
+    // Submit envelope
+    let envelope = build_test_envelope();
+    let result = target.submit_message(envelope).await;
+
+    assert!(
+        result.is_ok(),
+        "URL-embedded auth should work: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_explicit_auth_takes_precedence() {
+    // Start mock server expecting EXPLICIT auth, NOT URL-embedded auth
+    let mock_server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/v1/submit"))
+        .and(header(
+            "Authorization",
+            "Basic Y29uZmlnX3VzZXI6Y29uZmlnX3Bhc3M=", // base64("config_user:config_pass")
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Create HttpTarget with BOTH URL-embedded and explicit auth
+    // Explicit should win
+    let url_with_auth = format!("http://url_user:url_pass@{}", mock_server.address());
+    let config = HttpTargetConfig::new(url_with_auth, TargetKind::Stable)
+        .with_auth("config_user", "config_pass");
+
+    let target = HttpTarget::new(config).expect("Failed to create HttpTarget");
+
+    // Submit envelope
+    let envelope = build_test_envelope();
+    let result = target.submit_message(envelope).await;
+
+    assert!(
+        result.is_ok(),
+        "Explicit auth should take precedence: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_no_auth_no_header() {
+    // Start mock server expecting NO Authorization header
+    let mock_server = MockServer::start().await;
+
+    // This mock will match requests WITHOUT Authorization header
+    Mock::given(method("POST"))
+        .and(NoAuthHeader)
+        .and(path("/api/v1/submit"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Create HttpTarget without any auth
+    let config = HttpTargetConfig::new(mock_server.uri(), TargetKind::Stable);
+
+    let target = HttpTarget::new(config).expect("Failed to create HttpTarget");
+
+    // Submit envelope
+    let envelope = build_test_envelope();
+    let result = target.submit_message(envelope).await;
+
+    assert!(
+        result.is_ok(),
+        "No auth should mean no Authorization header: {:?}",
+        result.err()
+    );
+}
+
+#[tokio::test]
+async fn test_tombstone_uses_explicit_auth() {
+    // Start mock server expecting explicit auth for tombstone submission
+    let mock_server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/submit"))
+        .and(header(
+            "Authorization",
+            "Basic dG9tYl91c2VyOnRvbWJfcGFzcw==", // base64("tomb_user:tomb_pass")
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": "ok"
+        })))
+        .expect(1)
+        .mount(&mock_server)
+        .await;
+
+    // Create HttpTarget with explicit auth
+    let config = HttpTargetConfig::new(mock_server.uri(), TargetKind::Stable)
+        .with_auth("tomb_user", "tomb_pass");
+
+    let target = HttpTarget::new(config).expect("Failed to create HttpTarget");
+
+    // Submit tombstone
+    let tombstone = build_test_tombstone();
+    let result = target.submit_ack_tombstone(tombstone).await;
+
+    assert!(
+        result.is_ok(),
+        "Explicit auth should be applied to tombstone: {:?}",
+        result.err()
+    );
+}


### PR DESCRIPTION
## Summary

Fixes client HTTP transports ignoring `username`/`password` config fields, which caused 401 errors on protected mailboxes.

## Problem

When users configured HTTP peers with explicit credentials:
```toml
[[peers.http]]
url = "https://mailbox.example.com"
username = "alice"
password = "secret123"
```

The client would ignore these credentials and receive **401 Unauthorized** errors from protected mailboxes.

**Root cause:** `ParsedHttpPeer::auth` was populated from config but never applied when creating `HttpTarget`.

## Solution

Added `auth` field to `HttpTargetConfig` and applied it with correct precedence:
1. **Priority 1:** Explicit config auth (`username`/`password` fields)
2. **Priority 2:** URL-embedded auth (`http://user:pass@host/`)
3. **Priority 3:** No auth (no Authorization header)

## Changes

- **Transport layer:** Added `auth` field to `HttpTargetConfig` with `with_auth()` builder method
- **Auth application:** Updated `submit_payload()` and `fetch_from_endpoint()` to apply config auth with precedence
- **Client integration:** Client now applies `parsed_peer.auth` when building HTTP transports
- **Tests:** Added 5 integration tests using `wiremock` to verify auth precedence

## Backward Compatibility

✅ URL-embedded auth still works (`http://user:pass@host/`)
✅ Explicit auth takes precedence when both exist
✅ No auth = no Authorization header (unchanged behavior)

## Node Replication

No changes needed - node replication was already correct (applies `peer_config.auth`).

## Testing

- ✅ All 395 workspace tests pass (including 5 new auth tests)
- ✅ Clean compilation (no warnings)
- ✅ No regressions
- ✅ Code simplifier review: minimal, correct, well-tested

## Files Changed

- `crates/reme-transport/src/http_target.rs` - Auth infrastructure and application
- `apps/client/src/tui/app.rs` - Client applies auth
- `crates/reme-transport/tests/http_auth_test.rs` - Integration tests (new)
- `crates/reme-transport/Cargo.toml` - Added `wiremock` dev-dependency

## Related Issues

Resolves issue where HTTP authentication credentials from config files were not being applied to protected mailbox connections.