### PR TITLE
Fix destructive mailbox fetch semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2639,6 +2639,7 @@ name = "reme-storage"
 version = "0.1.0"
 dependencies = [
  "bincode",
+ "hex",
  "reme-identity",
  "reme-message",
  "reme-node-core",

--- a/crates/reme-core/src/lib.rs
+++ b/crates/reme-core/src/lib.rs
@@ -60,6 +60,9 @@ pub enum ClientError {
 
     #[error("Invalid sender signature: message may be forged or tampered")]
     InvalidSenderSignature,
+
+    #[error("Conflicting duplicate message ID: {0:?}")]
+    ConflictingDuplicate(MessageID),
 }
 
 /// Represents a contact in the messenger
@@ -591,9 +594,27 @@ impl<T: Transport> Client<T> {
         // Compute content_id for DAG tracking
         let content_id = inner.content_id();
 
-        // Store received message - fail if storage fails to prevent data loss
-        self.storage
-            .store_received_message(contact_id, outer.message_id, &inner.content)?;
+        // Store received message. Duplicate delivery is expected once fetch becomes
+        // non-destructive, so treat an existing message_id as idempotent.
+        let is_duplicate =
+            match self
+                .storage
+                .store_received_message(contact_id, outer.message_id, &inner.content)
+            {
+                Ok(()) => false,
+                Err(StorageError::AlreadyExists) => {
+                    if !self.storage.received_message_matches(
+                        contact_id,
+                        outer.message_id,
+                        &inner.content,
+                    )? {
+                        return Err(ClientError::ConflictingDuplicate(outer.message_id));
+                    }
+                    debug!(message_id = ?outer.message_id, "Duplicate message delivery");
+                    true
+                }
+                Err(e) => return Err(e.into()),
+            };
 
         // NOW send auto-tombstone (fire-and-forget) AFTER successful message storage.
         // This ensures we never lose the message: if storage fails, we don't send tombstone.
@@ -731,8 +752,8 @@ impl<T: Transport> Client<T> {
         }
 
         debug!(
-            "Message received (content_id: {:?}, has_gaps: {}, sender_reset: {}, local_behind: {})",
-            content_id, has_gaps, sender_state_reset, local_state_behind
+            "Message received (content_id: {:?}, duplicate: {}, has_gaps: {}, sender_reset: {}, local_behind: {})",
+            content_id, is_duplicate, has_gaps, sender_state_reset, local_state_behind
         );
 
         Ok(ReceivedMessage {
@@ -1611,6 +1632,163 @@ mod tests {
             Content::Text(text) => assert_eq!(text.body, "Hello Bob!"),
             _ => panic!("Expected text content"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_process_message_is_idempotent_for_duplicate_delivery() {
+        let shared_transport = Arc::new(MockTransport::new());
+
+        let alice_identity = Identity::generate();
+        let alice_storage = Storage::in_memory().unwrap();
+        let alice = Client::new(alice_identity, shared_transport.clone(), alice_storage);
+
+        let bob_identity = Identity::generate();
+        let bob_storage = Storage::in_memory().unwrap();
+        let bob = Client::new(bob_identity, shared_transport.clone(), bob_storage);
+
+        alice.add_contact(bob.public_id(), Some("Bob")).unwrap();
+        alice
+            .send_text(bob.public_id(), "Hello twice")
+            .await
+            .unwrap();
+
+        let messages = shared_transport.take_messages();
+        assert_eq!(messages.len(), 1);
+
+        let first = bob.process_message(&messages[0]).await.unwrap();
+        let second = bob.process_message(&messages[0]).await.unwrap();
+
+        assert_eq!(first.message_id, second.message_id);
+        assert_eq!(first.from, second.from);
+        match (first.content, second.content) {
+            (Content::Text(first_text), Content::Text(second_text)) => {
+                assert_eq!(first_text.body, "Hello twice");
+                assert_eq!(second_text.body, "Hello twice");
+            }
+            _ => panic!("Expected text content"),
+        }
+    }
+
+    #[tokio::test]
+    #[allow(clippy::cast_possible_truncation)] // Test code, ms since epoch fits in u64
+    async fn test_duplicate_delivery_preserves_gap_detection() {
+        use reme_encryption::encrypt_to_mik;
+        use reme_message::{ContentId, InnerEnvelope, TextContent};
+
+        let shared_transport = Arc::new(MockTransport::new());
+
+        let alice_identity = Identity::generate();
+        let alice_private_key = alice_identity.to_bytes();
+        let alice_storage = Storage::in_memory().unwrap();
+        let alice = Client::new(alice_identity, shared_transport.clone(), alice_storage);
+
+        let bob_identity = Identity::generate();
+        let bob_storage = Storage::in_memory().unwrap();
+        let bob = Client::new(bob_identity, shared_transport.clone(), bob_storage);
+
+        bob.add_contact(alice.public_id(), Some("Alice")).unwrap();
+
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        let message_id = MessageID::new();
+        let missing_parent: ContentId = [0xAA; 8];
+        let inner = InnerEnvelope {
+            from: *alice.public_id(),
+            created_at_ms: now_ms,
+            content: Content::Text(TextContent {
+                body: "Out of order".to_string(),
+            }),
+            prev_self: Some(missing_parent),
+            observed_heads: Vec::new(),
+            epoch: 0,
+            flags: 0,
+        };
+
+        let enc_output =
+            encrypt_to_mik(&inner, bob.public_id(), &message_id, &alice_private_key).unwrap();
+        let outer = OuterEnvelope {
+            version: CURRENT_VERSION,
+            routing_key: bob.public_id().routing_key(),
+            timestamp_hours: reme_message::now_hours(),
+            ttl_hours: None,
+            message_id,
+            ephemeral_key: enc_output.ephemeral_public,
+            ack_hash: enc_output.ack_hash,
+            inner_ciphertext: enc_output.ciphertext,
+        };
+
+        let first = bob.process_message(&outer).await.unwrap();
+        let second = bob.process_message(&outer).await.unwrap();
+
+        assert!(first.has_gaps);
+        assert!(second.has_gaps);
+        assert_eq!(first.content_id, second.content_id);
+    }
+
+    #[tokio::test]
+    #[allow(clippy::cast_possible_truncation)] // Test code, ms since epoch fits in u64
+    async fn test_conflicting_duplicate_message_id_is_rejected() {
+        use reme_encryption::encrypt_to_mik;
+        use reme_message::{InnerEnvelope, TextContent};
+
+        let shared_transport = Arc::new(MockTransport::new());
+
+        let alice_identity = Identity::generate();
+        let alice_private_key = alice_identity.to_bytes();
+        let alice_storage = Storage::in_memory().unwrap();
+        let alice = Client::new(alice_identity, shared_transport.clone(), alice_storage);
+
+        let bob_identity = Identity::generate();
+        let bob_storage = Storage::in_memory().unwrap();
+        let bob = Client::new(bob_identity, shared_transport.clone(), bob_storage);
+
+        bob.add_contact(alice.public_id(), Some("Alice")).unwrap();
+
+        let message_id = MessageID::new();
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+
+        let make_outer = |body: &str, created_at_ms: u64| {
+            let inner = InnerEnvelope {
+                from: *alice.public_id(),
+                created_at_ms,
+                content: Content::Text(TextContent {
+                    body: body.to_string(),
+                }),
+                prev_self: None,
+                observed_heads: Vec::new(),
+                epoch: 0,
+                flags: 0,
+            };
+
+            let enc_output =
+                encrypt_to_mik(&inner, bob.public_id(), &message_id, &alice_private_key).unwrap();
+            OuterEnvelope {
+                version: CURRENT_VERSION,
+                routing_key: bob.public_id().routing_key(),
+                timestamp_hours: reme_message::now_hours(),
+                ttl_hours: None,
+                message_id,
+                ephemeral_key: enc_output.ephemeral_public,
+                ack_hash: enc_output.ack_hash,
+                inner_ciphertext: enc_output.ciphertext,
+            }
+        };
+
+        let first = make_outer("Original", now_ms);
+        bob.process_message(&first).await.unwrap();
+
+        let conflicting = make_outer("Tampered", now_ms + 1);
+        let result = bob.process_message(&conflicting).await;
+
+        assert!(matches!(
+            result,
+            Err(ClientError::ConflictingDuplicate(id)) if id == message_id
+        ));
     }
 
     #[tokio::test]

--- a/crates/reme-node-core/src/mailbox_store.rs
+++ b/crates/reme-node-core/src/mailbox_store.rs
@@ -29,6 +29,9 @@ const fn default_ttl_secs() -> u64 {
     7 * 24 * 60 * 60
 }
 
+/// `SQLite` commonly defaults to 999 bound parameters per statement.
+const SQLITE_MAX_BOUND_VARIABLES: usize = 999;
+
 /// Configuration for the persistent store
 #[derive(Debug, Clone, Derivative)]
 #[derivative(Default)]
@@ -87,7 +90,7 @@ pub trait MailboxStore: Send + Sync {
     /// Store a message in the mailbox for the given routing key
     fn enqueue(&self, routing_key: RoutingKey, envelope: OuterEnvelope) -> Result<(), NodeError>;
 
-    /// Fetch and remove all messages for the given routing key
+    /// Fetch all messages for the given routing key
     fn fetch(&self, routing_key: &RoutingKey) -> Result<Vec<OuterEnvelope>, NodeError>;
 
     /// Check if a message with the given ID exists for the routing key
@@ -441,43 +444,41 @@ impl MailboxStore for PersistentMailboxStore {
         })?;
 
         let mut envelopes = Vec::new();
-        let mut ids_to_delete = Vec::new();
+        let mut invalid_ids_to_delete = Vec::new();
 
         for row in rows {
             let (id, data) = row?;
             match Self::deserialize_envelope(&data) {
                 Ok(envelope) => {
                     envelopes.push(envelope);
-                    ids_to_delete.push(id);
                 }
                 Err(e) => {
                     warn!(id = id, error = %e, "failed to deserialize envelope, deleting");
-                    ids_to_delete.push(id);
+                    invalid_ids_to_delete.push(id);
                 }
             }
         }
 
-        // Delete fetched messages
-        if !ids_to_delete.is_empty() {
-            let placeholders: Vec<&str> = ids_to_delete.iter().map(|_| "?").collect();
-            let sql = format!(
-                "DELETE FROM mailbox_messages WHERE id IN ({})",
-                placeholders.join(",")
-            );
+        if !invalid_ids_to_delete.is_empty() {
+            for chunk in invalid_ids_to_delete.chunks(SQLITE_MAX_BOUND_VARIABLES) {
+                let placeholders: Vec<&str> = chunk.iter().map(|_| "?").collect();
+                let sql = format!(
+                    "DELETE FROM mailbox_messages WHERE id IN ({})",
+                    placeholders.join(",")
+                );
 
-            let mut stmt = conn.prepare(&sql)?;
-            let params: Vec<&dyn rusqlite::ToSql> = ids_to_delete
-                .iter()
-                .map(|id| id as &dyn rusqlite::ToSql)
-                .collect();
-            stmt.execute(params.as_slice())?;
-
-            debug!(
-                routing_key = ?&routing_key[..4],
-                count = envelopes.len(),
-                "messages fetched and deleted"
-            );
+                let mut stmt = conn.prepare(&sql)?;
+                let params: Vec<&dyn rusqlite::ToSql> =
+                    chunk.iter().map(|id| id as &dyn rusqlite::ToSql).collect();
+                stmt.execute(params.as_slice())?;
+            }
         }
+
+        debug!(
+            routing_key = ?&routing_key[..4],
+            count = envelopes.len(),
+            "messages fetched"
+        );
 
         Ok(envelopes)
     }
@@ -556,7 +557,7 @@ mod tests {
     }
 
     #[test]
-    fn test_enqueue_and_fetch() {
+    fn test_fetch_is_non_destructive_until_delete() {
         let config = PersistentStoreConfig::default();
         let store = PersistentMailboxStore::in_memory(config).unwrap();
         let routing_key = RoutingKey::from_bytes([1u8; 16]);
@@ -572,9 +573,15 @@ mod tests {
         assert_eq!(fetched.len(), 1);
         assert_eq!(fetched[0].message_id, message_id);
 
-        // Should be empty after fetch
+        // Fetch should not delete. Tombstones are the deletion path.
         let fetched_again = store.fetch(&routing_key).unwrap();
-        assert!(fetched_again.is_empty());
+        assert_eq!(fetched_again.len(), 1);
+        assert_eq!(fetched_again[0].message_id, message_id);
+
+        // Explicit deletion should clear it.
+        assert!(store.delete_message(&message_id).unwrap());
+        let fetched_after_delete = store.fetch(&routing_key).unwrap();
+        assert!(fetched_after_delete.is_empty());
     }
 
     #[test]
@@ -653,6 +660,72 @@ mod tests {
         assert!(deleted);
 
         assert!(!store.has_message(&routing_key, &message_id).unwrap());
+    }
+
+    #[test]
+    fn test_fetch_deletes_invalid_rows_only() {
+        let config = PersistentStoreConfig::default();
+        let store = PersistentMailboxStore::in_memory(config).unwrap();
+        let routing_key = RoutingKey::from_bytes([8u8; 16]);
+        let message_id = MessageID::new();
+        let expires_at = timestamp_to_i64(now_secs() + 3600);
+        let created_at = timestamp_to_i64(now_secs());
+
+        {
+            let conn = store.conn.lock().unwrap();
+            conn.execute(
+                "INSERT INTO mailbox_messages
+                 (routing_key, message_id, envelope_data, expires_at, created_at)
+                 VALUES (?, ?, ?, ?, ?)",
+                params![
+                    &routing_key[..],
+                    &message_id.as_bytes()[..],
+                    &[0xFFu8, 0x00, 0x01][..],
+                    expires_at,
+                    created_at
+                ],
+            )
+            .unwrap();
+        }
+
+        assert!(store.has_message(&routing_key, &message_id).unwrap());
+
+        let fetched = store.fetch(&routing_key).unwrap();
+        assert!(fetched.is_empty());
+        assert!(!store.has_message(&routing_key, &message_id).unwrap());
+    }
+
+    #[test]
+    fn test_fetch_deletes_invalid_rows_in_batches() {
+        let config = PersistentStoreConfig::default();
+        let store = PersistentMailboxStore::in_memory(config).unwrap();
+        let routing_key = RoutingKey::from_bytes([9u8; 16]);
+        let expires_at = timestamp_to_i64(now_secs() + 3600);
+        let created_at = timestamp_to_i64(now_secs());
+
+        {
+            let conn = store.conn.lock().unwrap();
+            for _ in 0..1000 {
+                let message_id = MessageID::new();
+                conn.execute(
+                    "INSERT INTO mailbox_messages
+                     (routing_key, message_id, envelope_data, expires_at, created_at)
+                     VALUES (?, ?, ?, ?, ?)",
+                    params![
+                        &routing_key[..],
+                        &message_id.as_bytes()[..],
+                        &[0xFFu8, 0x00, 0x01][..],
+                        expires_at,
+                        created_at
+                    ],
+                )
+                .unwrap();
+            }
+        }
+
+        let fetched = store.fetch(&routing_key).unwrap();
+        assert!(fetched.is_empty());
+        assert!(store.get_message_ids(&routing_key).unwrap().is_empty());
     }
 
     #[test]

--- a/crates/reme-storage/Cargo.toml
+++ b/crates/reme-storage/Cargo.toml
@@ -16,6 +16,7 @@ rusqlite = { workspace = true }
 thiserror = { workspace = true }
 bincode = { workspace = true }
 tracing = { workspace = true }
+hex = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.13"

--- a/crates/reme-storage/src/lib.rs
+++ b/crates/reme-storage/src/lib.rs
@@ -1,5 +1,5 @@
 use reme_identity::{InvalidPublicKey, PublicID};
-use reme_message::{Content, ContentId, MessageID};
+use reme_message::{Content, ContentId, MessageID, ReceiptContent, ReceiptKind};
 use reme_node_core::{
     now_ms, now_secs_i64, timestamp_opt_to_i64, timestamp_to_i64, NodeError,
     PersistentMailboxStore, PersistentStoreConfig,
@@ -8,7 +8,7 @@ use reme_outbox::{
     AttemptError, AttemptResult, DeliveryConfidence, DeliveryConfirmation, OutboxEntryId,
     OutboxStore, PendingMessage, TargetId, TieredDeliveryPhase, TransportAttempt,
 };
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, ErrorCode, OptionalExtension};
 use std::path::PathBuf;
 use std::sync::Mutex;
 use thiserror::Error;
@@ -388,11 +388,7 @@ impl Storage {
         trace!(contact_id = contact_id, ?message_id, "storing sent message");
         let now = now_secs_i64();
 
-        let (content_type, body) = match content {
-            Content::Text(text) => ("text", Some(text.body.as_str())),
-            Content::Receipt(_) => ("receipt", None),
-            _ => ("unknown", None),
-        };
+        let (content_type, body) = encode_content(content);
 
         let message_id_bytes = message_id.as_bytes();
 
@@ -400,7 +396,13 @@ impl Storage {
         conn.execute(
             "INSERT INTO messages (message_id, contact_id, direction, content_type, body, created_at)
              VALUES (?, ?, 'sent', ?, ?, ?)",
-            params![&message_id_bytes[..], contact_id, content_type, body, now],
+            params![
+                &message_id_bytes[..],
+                contact_id,
+                content_type,
+                body.as_deref(),
+                now
+            ],
         )?;
 
         Ok(())
@@ -420,11 +422,7 @@ impl Storage {
         );
         let now = now_secs_i64();
 
-        let (content_type, body) = match content {
-            Content::Text(text) => ("text", Some(text.body.as_str())),
-            Content::Receipt(_) => ("receipt", None),
-            _ => ("unknown", None),
-        };
+        let (content_type, body) = encode_content(content);
 
         let message_id_bytes = message_id.as_bytes();
 
@@ -432,10 +430,69 @@ impl Storage {
         conn.execute(
             "INSERT INTO messages (message_id, contact_id, direction, content_type, body, created_at)
              VALUES (?, ?, 'received', ?, ?, ?)",
-            params![&message_id_bytes[..], contact_id, content_type, body, now],
-        )?;
+            params![
+                &message_id_bytes[..],
+                contact_id,
+                content_type,
+                body.as_deref(),
+                now
+            ],
+        )
+        .map_err(|e| {
+            if is_duplicate_message_id_error(&e) {
+                StorageError::AlreadyExists
+            } else {
+                StorageError::Database(e)
+            }
+        })?;
 
         Ok(())
+    }
+
+    /// Check whether an existing message row matches an incoming received message.
+    ///
+    /// This is used to distinguish benign duplicate delivery from a conflicting
+    /// reuse of an existing `message_id`.
+    pub fn received_message_matches(
+        &self,
+        contact_id: i64,
+        message_id: MessageID,
+        content: &Content,
+    ) -> Result<bool, StorageError> {
+        let expected_content_type = content_type_name(content);
+        let expected_body = encoded_body(content);
+        let message_id_bytes = message_id.as_bytes();
+
+        let conn = self.conn.lock().expect("mutex poisoned");
+        let row: Option<(i64, String, String, Option<String>)> = conn
+            .query_row(
+                "SELECT contact_id, direction, content_type, body
+                 FROM messages
+                 WHERE message_id = ?",
+                params![&message_id_bytes[..]],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()?;
+
+        let Some((stored_contact_id, direction, stored_content_type, stored_body)) = row else {
+            return Ok(false);
+        };
+
+        if direction != "received" || stored_contact_id != contact_id {
+            return Ok(false);
+        }
+
+        if stored_content_type != expected_content_type {
+            return Ok(false);
+        }
+
+        if matches!(content, Content::Receipt(_)) && stored_body.is_none() {
+            // Legacy receipt rows were stored without a serialized body. Treat
+            // type/contact match as equivalent for backward compatibility.
+            return Ok(true);
+        }
+
+        Ok(stored_body == expected_body)
     }
 
     /// Mark a message as delivered
@@ -863,6 +920,47 @@ impl Storage {
             tiered_phase,
         })
     }
+}
+
+fn content_type_name(content: &Content) -> &'static str {
+    match content {
+        Content::Text(_) => "text",
+        Content::Receipt(_) => "receipt",
+        _ => "unknown",
+    }
+}
+
+fn encoded_body(content: &Content) -> Option<String> {
+    match content {
+        Content::Text(text) => Some(text.body.clone()),
+        Content::Receipt(receipt) => Some(encode_receipt_body(receipt)),
+        _ => None,
+    }
+}
+
+fn encode_content(content: &Content) -> (&'static str, Option<String>) {
+    (content_type_name(content), encoded_body(content))
+}
+
+fn encode_receipt_body(receipt: &ReceiptContent) -> String {
+    format!(
+        "{}:{}",
+        match receipt.kind {
+            ReceiptKind::Delivered => "delivered",
+            ReceiptKind::Read => "read",
+            _ => "unknown",
+        },
+        hex::encode(receipt.target_message_id.as_bytes())
+    )
+}
+
+fn is_duplicate_message_id_error(error: &rusqlite::Error) -> bool {
+    matches!(
+        error,
+        rusqlite::Error::SqliteFailure(inner, Some(message))
+            if inner.code == ErrorCode::ConstraintViolation
+                && message.contains("messages.message_id")
+    )
 }
 
 // ============================================
@@ -1684,6 +1782,29 @@ mod tests {
             .unwrap();
         storage.mark_delivered(msg_id).unwrap();
         storage.mark_read(msg_id).unwrap();
+    }
+
+    #[test]
+    fn test_received_message_duplicate_returns_already_exists() {
+        let storage = Storage::in_memory().unwrap();
+        let contact = Identity::generate();
+        let contact_id = storage
+            .add_contact(contact.public_id(), Some("Bob"))
+            .unwrap();
+        let msg_id = MessageID::new();
+        let content = Content::Text(reme_message::TextContent {
+            body: "Hello again".to_string(),
+        });
+
+        storage
+            .store_received_message(contact_id, msg_id, &content)
+            .unwrap();
+
+        let duplicate = storage.store_received_message(contact_id, msg_id, &content);
+        assert!(matches!(duplicate, Err(StorageError::AlreadyExists)));
+        assert!(storage
+            .received_message_matches(contact_id, msg_id, &content)
+            .unwrap());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Make mailbox fetch non-destructive so tombstones remain the explicit deletion path
- Keep malformed mailbox rows self-healing by deleting only invalid entries during fetch
- Make duplicate receive processing idempotent so repeated fetches do not fail clients

Closes #65


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Message processing is idempotent for duplicate deliveries and now rejects conflicting duplicates (same ID, different content).

* **Improvements**
  * Mailbox fetch is non-destructive by default; only corrupted/invalid rows are removed, cleaned in batches.
  * Storage now reliably detects duplicate message IDs and logs duplicate deliveries with a duplicate flag for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->