### PR TITLE
fix(transport): preserve conflicting envelopes during multi-node fetch

### DIFF
--- a/crates/reme-message/src/lib.rs
+++ b/crates/reme-message/src/lib.rs
@@ -151,7 +151,7 @@ pub const CURRENT_VERSION: Version = Version { major: 0, minor: 0 };
 /// 1. Computes `shared_secret` = `X25519(mik_private`, `ephemeral_key`)
 /// 2. Derives same encryption key
 /// 3. Decrypts `InnerEnvelope`
-#[derive(Debug, Clone, Encode, Decode)]
+#[derive(Debug, Clone, PartialEq, Eq, Encode, Decode)]
 pub struct OuterEnvelope {
     pub version: Version,
 

--- a/crates/reme-transport/src/coordinator.rs
+++ b/crates/reme-transport/src/coordinator.rs
@@ -250,16 +250,25 @@ impl TransportCoordinator {
                     _ = poll_interval.tick() => {
                         match pool.fetch_once(&routing_key).await {
                             Ok(messages) => {
+                                // Collect IDs to mark after forwarding, so
+                                // byte-distinct variants within the same batch
+                                // are not suppressed by check_and_mark.
+                                let mut ids_to_mark = Vec::new();
                                 for envelope in messages {
-                                    // Deduplicate across transports
-                                    if seen_cache.check_and_mark(&envelope.message_id) {
-                                        if tx.send(TransportEvent::Message(envelope)).is_err() {
-                                            debug!("Coordinator: channel closed");
-                                            return;
-                                        }
-                                    } else {
+                                    // Cross-poll dedup: skip messages already
+                                    // forwarded in a previous poll cycle.
+                                    if seen_cache.was_seen(&envelope.message_id) {
                                         trace!("Coordinator: duplicate message skipped");
+                                        continue;
                                     }
+                                    ids_to_mark.push(envelope.message_id);
+                                    if tx.send(TransportEvent::Message(envelope)).is_err() {
+                                        debug!("Coordinator: channel closed");
+                                        return;
+                                    }
+                                }
+                                for id in &ids_to_mark {
+                                    seen_cache.mark(id);
                                 }
                             }
                             Err(e) => {

--- a/crates/reme-transport/src/dedup.rs
+++ b/crates/reme-transport/src/dedup.rs
@@ -1,0 +1,107 @@
+use std::collections::HashMap;
+
+use reme_message::{MessageID, OuterEnvelope};
+use tracing::warn;
+
+/// Merge envelopes from multiple sources, preserving all distinct variants
+/// per `message_id`.
+///
+/// When two envelopes share a `message_id` but differ in content,
+/// all distinct copies are kept. The caller (decryption layer) will
+/// naturally reject tampered copies.
+pub fn merge_envelopes(
+    accumulated: &mut HashMap<MessageID, Vec<OuterEnvelope>>,
+    incoming: Vec<OuterEnvelope>,
+    source_label: &str,
+) {
+    for envelope in incoming {
+        let variants = accumulated.entry(envelope.message_id).or_default();
+
+        if variants.iter().any(|v| v == &envelope) {
+            continue;
+        }
+
+        if !variants.is_empty() {
+            warn!(
+                message_id = ?envelope.message_id,
+                source = source_label,
+                existing_variants = variants.len(),
+                "Conflicting envelope: same message_id, different content. \
+                 Preserving all variants for client-side resolution.",
+            );
+        }
+
+        variants.push(envelope);
+    }
+}
+
+/// Flatten the accumulated map into a single `Vec` of all distinct envelopes.
+pub fn flatten_variants(map: HashMap<MessageID, Vec<OuterEnvelope>>) -> Vec<OuterEnvelope> {
+    map.into_values().flatten().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reme_identity::RoutingKey;
+
+    fn make_envelope_with_id(message_id: MessageID, ciphertext: Vec<u8>) -> OuterEnvelope {
+        let mut env = OuterEnvelope::new(
+            RoutingKey::from([0u8; 16]),
+            None,
+            [0u8; 32],
+            [0u8; 16],
+            ciphertext,
+        );
+        env.message_id = message_id;
+        env
+    }
+
+    #[test]
+    fn test_identical_envelopes_deduplicated() {
+        let id = MessageID::from_bytes([1; 16]);
+        let env1 = make_envelope_with_id(id, vec![0xAA; 50]);
+        let env2 = env1.clone();
+
+        let mut map = HashMap::new();
+        merge_envelopes(&mut map, vec![env1], "node-a");
+        merge_envelopes(&mut map, vec![env2], "node-b");
+
+        let result = flatten_variants(map);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_conflicting_envelopes_preserved() {
+        let id = MessageID::from_bytes([1; 16]);
+        let env1 = make_envelope_with_id(id, vec![0xAA; 50]);
+        let env2 = make_envelope_with_id(id, vec![0xBB; 50]);
+
+        let mut map = HashMap::new();
+        merge_envelopes(&mut map, vec![env1], "node-a");
+        merge_envelopes(&mut map, vec![env2], "node-b");
+
+        let result = flatten_variants(map);
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].message_id, result[1].message_id);
+    }
+
+    #[test]
+    fn test_different_message_ids_preserved() {
+        let env1 = make_envelope_with_id(MessageID::from_bytes([1; 16]), vec![0xAA; 50]);
+        let env2 = make_envelope_with_id(MessageID::from_bytes([2; 16]), vec![0xBB; 50]);
+
+        let mut map = HashMap::new();
+        merge_envelopes(&mut map, vec![env1, env2], "node-a");
+
+        let result = flatten_variants(map);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_flatten_empty() {
+        let map: HashMap<MessageID, Vec<OuterEnvelope>> = HashMap::new();
+        let result = flatten_variants(map);
+        assert!(result.is_empty());
+    }
+}

--- a/crates/reme-transport/src/http.rs
+++ b/crates/reme-transport/src/http.rs
@@ -404,8 +404,8 @@ impl HttpTransport {
 
         let results = join_all(futures).await;
 
-        // Aggregate and deduplicate by message_id
-        let mut messages_by_id: HashMap<MessageID, OuterEnvelope> = HashMap::new();
+        // Aggregate and deduplicate by message_id, preserving conflicting variants
+        let mut accumulated: HashMap<MessageID, Vec<OuterEnvelope>> = HashMap::new();
         let mut last_error = None;
         let mut success_count = 0;
 
@@ -418,9 +418,11 @@ impl HttpTransport {
                         self.base_urls[i]
                     );
                     success_count += 1;
-                    for msg in messages {
-                        messages_by_id.insert(msg.message_id, msg);
-                    }
+                    crate::dedup::merge_envelopes(
+                        &mut accumulated,
+                        messages,
+                        &sanitize_url_for_log(&self.base_urls[i]),
+                    );
                 }
                 Err(e) => {
                     warn!("Failed to fetch from node {}: {}", self.base_urls[i], e);
@@ -431,7 +433,7 @@ impl HttpTransport {
 
         // If we got messages from at least one node, return them
         if success_count > 0 {
-            let messages: Vec<_> = messages_by_id.into_values().collect();
+            let messages = crate::dedup::flatten_variants(accumulated);
             debug!(
                 "Fetched {} unique messages from {}/{} nodes",
                 messages.len(),
@@ -987,5 +989,115 @@ mod tests {
             Err(e) => panic!("Expected ServerError, got: {e:?}"),
             Ok(_) => panic!("Expected error, got success"),
         }
+    }
+
+    /// Build a test envelope with a specific `message_id` and ciphertext.
+    fn build_envelope_with_id(
+        message_id: reme_message::MessageID,
+        ciphertext: Vec<u8>,
+    ) -> OuterEnvelope {
+        let mut env = OuterEnvelope::new(
+            reme_identity::RoutingKey::from([0u8; 16]),
+            None,
+            [0u8; 32],
+            [0u8; 16],
+            ciphertext,
+        );
+        env.message_id = message_id;
+        env
+    }
+
+    /// Encode an envelope as a base64 wire payload string (for mock server responses).
+    fn encode_envelope_payload(env: &OuterEnvelope) -> String {
+        let wire = WirePayload::Message(env.clone());
+        BASE64_STANDARD.encode(wire.encode())
+    }
+
+    #[derive(Serialize)]
+    struct MockFetchResponse {
+        payloads: Vec<String>,
+    }
+
+    #[tokio::test]
+    async fn test_fetch_once_conflicting_envelopes() {
+        let msg_id = reme_message::MessageID::from_bytes([0x42; 16]);
+        let env_a = build_envelope_with_id(msg_id, vec![0xAA; 50]);
+        let env_b = build_envelope_with_id(msg_id, vec![0xBB; 50]);
+
+        let payload_a = encode_envelope_payload(&env_a);
+        let payload_b = encode_envelope_payload(&env_b);
+
+        let app_a = Router::new().route(
+            "/api/v1/fetch/{routing_key}",
+            get(move || async move {
+                Json(MockFetchResponse {
+                    payloads: vec![payload_a.clone()],
+                })
+            }),
+        );
+
+        let app_b = Router::new().route(
+            "/api/v1/fetch/{routing_key}",
+            get(move || async move {
+                Json(MockFetchResponse {
+                    payloads: vec![payload_b.clone()],
+                })
+            }),
+        );
+
+        let (url_a, _h1) = start_mock_server(app_a).await;
+        let (url_b, _h2) = start_mock_server(app_b).await;
+
+        let transport = HttpTransport::with_nodes(vec![url_a, url_b]);
+        let routing_key = reme_identity::RoutingKey::from([0u8; 16]);
+        let result = transport.fetch_once(&routing_key).await.unwrap();
+
+        assert_eq!(
+            result.len(),
+            2,
+            "Both conflicting variants should be preserved"
+        );
+        assert!(result.contains(&env_a));
+        assert!(result.contains(&env_b));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_once_identical_envelopes_deduped() {
+        let msg_id = reme_message::MessageID::from_bytes([0x42; 16]);
+        let env = build_envelope_with_id(msg_id, vec![0xAA; 50]);
+
+        let payload = encode_envelope_payload(&env);
+        let payload_clone = payload.clone();
+
+        let app_a = Router::new().route(
+            "/api/v1/fetch/{routing_key}",
+            get(move || async move {
+                Json(MockFetchResponse {
+                    payloads: vec![payload.clone()],
+                })
+            }),
+        );
+
+        let app_b = Router::new().route(
+            "/api/v1/fetch/{routing_key}",
+            get(move || async move {
+                Json(MockFetchResponse {
+                    payloads: vec![payload_clone.clone()],
+                })
+            }),
+        );
+
+        let (url_a, _h1) = start_mock_server(app_a).await;
+        let (url_b, _h2) = start_mock_server(app_b).await;
+
+        let transport = HttpTransport::with_nodes(vec![url_a, url_b]);
+        let routing_key = reme_identity::RoutingKey::from([0u8; 16]);
+        let result = transport.fetch_once(&routing_key).await.unwrap();
+
+        assert_eq!(
+            result.len(),
+            1,
+            "Identical envelopes should be deduplicated"
+        );
     }
 }

--- a/crates/reme-transport/src/lib.rs
+++ b/crates/reme-transport/src/lib.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc;
 
 pub mod composite;
 pub mod coordinator;
+pub(crate) mod dedup;
 pub mod delivery;
 pub mod http;
 pub mod http_target;

--- a/crates/reme-transport/src/pool.rs
+++ b/crates/reme-transport/src/pool.rs
@@ -635,8 +635,8 @@ impl TransportPool<HttpTarget> {
 
         let results = join_all(futures).await;
 
-        // Aggregate and deduplicate by message_id
-        let mut messages_by_id: HashMap<MessageID, OuterEnvelope> = HashMap::new();
+        // Aggregate and deduplicate by message_id, preserving conflicting variants
+        let mut accumulated: HashMap<MessageID, Vec<OuterEnvelope>> = HashMap::new();
         let mut last_error = None;
         let mut success_count = 0;
 
@@ -644,9 +644,11 @@ impl TransportPool<HttpTarget> {
             match result {
                 Ok(messages) => {
                     success_count += 1;
-                    for msg in messages {
-                        messages_by_id.insert(msg.message_id, msg);
-                    }
+                    crate::dedup::merge_envelopes(
+                        &mut accumulated,
+                        messages,
+                        targets[i].id().as_str(),
+                    );
                 }
                 Err(e) => {
                     warn!("Target {} fetch failed: {}", targets[i].id(), e);
@@ -657,7 +659,7 @@ impl TransportPool<HttpTarget> {
 
         // If we got messages from at least one target, return them
         if success_count > 0 {
-            let messages: Vec<_> = messages_by_id.into_values().collect();
+            let messages = crate::dedup::flatten_variants(accumulated);
             debug!(
                 "Fetched {} unique messages from {}/{} targets",
                 messages.len(),


### PR DESCRIPTION
## Summary

- Multi-node fetch deduplication used `HashMap::insert` (last-write-wins), allowing a compromised relay to silently overwrite valid envelopes with tampered copies sharing the same `message_id`
- Replace with conflict-aware dedup that preserves all byte-distinct variants per `message_id` — the decryption layer naturally rejects tampered copies, so no downstream API changes needed
- Extract shared merge logic into `dedup` module, log conflicting envelopes as security warnings

Closes #66

## Follow-up

#72 tracks a longer-term improvement: moving decryption/signature verification into the fetch aggregation step so tampered copies are rejected at transport time rather than relying on downstream decryption failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced message deduplication to preserve conflicting message variants, enabling client-side resolution when identical message IDs contain different content.
  * Improved deduplication consistency across message fetching and pooling, aggregating variants from multiple sources.
  * Outer envelope instances are now directly comparable for equality, aiding deduplication and testing.

* **Tests**
  * Added comprehensive tests covering deduplication, conflict preservation, and flattening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->