### PR TITLE
feat: coordinator mutation API and capability-filtered fetch

### DIFF
--- a/crates/reme-transport/src/coordinator.rs
+++ b/crates/reme-transport/src/coordinator.rs
@@ -169,6 +169,41 @@ impl TransportCoordinator {
         self.config.routing_strategy = strategy;
     }
 
+    /// Get a reference to the HTTP pool (for cases needing direct access).
+    pub fn http_pool(&self) -> Option<&Arc<TransportPool<HttpTarget>>> {
+        self.http_pool.as_ref()
+    }
+
+    /// Add an HTTP target at runtime (for discovered peers).
+    pub fn add_http_target(&self, target: HttpTarget) {
+        if let Some(ref pool) = self.http_pool {
+            pool.add_target(target);
+        }
+    }
+
+    /// Remove an HTTP target by ID (when peer disappears).
+    pub fn remove_http_target(&self, id: &TargetId) -> bool {
+        self.http_pool
+            .as_ref()
+            .is_some_and(|pool| pool.remove_target(id))
+    }
+
+    /// Replace an HTTP target atomically (e.g. when a discovered peer's address changes).
+    ///
+    /// Removes the target matching `old_id` (if present) and adds `new_target`
+    /// under a single pool write lock, so concurrent senders never observe a
+    /// state where neither target exists. Always adds `new_target` even if
+    /// `old_id` was not found (upsert semantics).
+    ///
+    /// Returns `true` if a target with `old_id` was found and removed.
+    pub fn replace_http_target(&self, old_id: &TargetId, new_target: HttpTarget) -> bool {
+        if let Some(ref pool) = self.http_pool {
+            pool.replace_target(old_id, new_target)
+        } else {
+            false
+        }
+    }
+
     /// Check if any transport pools are available.
     pub fn has_transports(&self) -> bool {
         let has_http = self.http_pool.as_ref().is_some_and(|p| p.has_available());
@@ -607,12 +642,12 @@ impl TransportCoordinator {
         let tier_timeout = config.quorum_tier_timeout;
         let message_id = envelope.message_id;
 
-        // Collect HTTP stable targets
+        // Collect HTTP targets with QUORUM_CREDIT capability
         let http_targets: Vec<Arc<HttpTarget>> = self
             .http_pool
             .as_ref()
             .map(|pool| {
-                pool.targets_by_kind(TargetKind::Stable)
+                pool.targets_where(|c| c.quorum_credit)
                     .into_iter()
                     .filter(|t| {
                         !config.is_excluded(t.id())
@@ -731,24 +766,25 @@ impl TransportCoordinator {
     }
 
     /// Get count of Quorum tier targets (for quorum calculation).
+    ///
+    /// Uses `capabilities.quorum_credit` to identify targets that
+    /// count toward quorum, rather than relying on `TargetKind`.
     #[allow(clippy::cast_possible_truncation)] // Target count won't exceed u32::MAX
     pub fn quorum_target_count(&self, config: &TieredDeliveryConfig) -> u32 {
         let mut count = 0u32;
 
-        // Count HTTP stable targets
         if let Some(ref pool) = self.http_pool {
             count += pool
-                .targets_by_kind(TargetKind::Stable)
+                .targets_where(|c| c.quorum_credit)
                 .iter()
                 .filter(|t| !config.is_excluded(t.id()) && t.is_available())
                 .count() as u32;
         }
 
-        // Count MQTT targets
         #[cfg(feature = "mqtt")]
         if let Some(ref pool) = self.mqtt_pool {
             count += pool
-                .all_targets()
+                .targets_where(|c| c.quorum_credit)
                 .iter()
                 .filter(|t| !config.is_excluded(t.id()) && t.is_available())
                 .count() as u32;
@@ -759,27 +795,29 @@ impl TransportCoordinator {
 
     /// Get all Quorum tier target IDs (for filtering in retry logic).
     ///
-    /// Returns target IDs of all stable HTTP and MQTT targets.
+    /// Returns target IDs of all targets with `QUORUM_CREDIT` capability.
     pub fn quorum_target_ids(&self, config: &TieredDeliveryConfig) -> Vec<TargetId> {
         let mut ids = Vec::new();
 
-        // HTTP stable target IDs
+        // HTTP targets with QUORUM_CREDIT capability
         if let Some(ref pool) = self.http_pool {
-            for target in pool.targets_by_kind(TargetKind::Stable) {
-                if !config.is_excluded(target.id()) && target.is_available() {
-                    ids.push(target.id().clone());
-                }
-            }
+            ids.extend(
+                pool.targets_where(|c| c.quorum_credit)
+                    .iter()
+                    .filter(|t| !config.is_excluded(t.id()) && t.is_available())
+                    .map(|t| t.id().clone()),
+            );
         }
 
-        // MQTT target IDs
+        // MQTT targets with QUORUM_CREDIT capability
         #[cfg(feature = "mqtt")]
         if let Some(ref pool) = self.mqtt_pool {
-            for target in pool.all_targets() {
-                if !config.is_excluded(target.id()) && target.is_available() {
-                    ids.push(target.id().clone());
-                }
-            }
+            ids.extend(
+                pool.targets_where(|c| c.quorum_credit)
+                    .iter()
+                    .filter(|t| !config.is_excluded(t.id()) && t.is_available())
+                    .map(|t| t.id().clone()),
+            );
         }
 
         ids
@@ -889,6 +927,7 @@ impl TransportQuery for TransportCoordinator {
 mod tests {
     use super::*;
     use crate::delivery::QuorumStrategy;
+    use crate::target::TargetCapabilities;
 
     #[test]
     fn test_default_config() {
@@ -1014,6 +1053,189 @@ mod tests {
         assert!(!result.any_success());
         assert_eq!(result.success_count(), 0);
         assert!(result.results.is_empty());
+    }
+
+    // ========================================================================
+    // COORDINATOR MUTATION API TESTS
+    // ========================================================================
+
+    #[test]
+    fn test_add_http_target() {
+        let mut coordinator = TransportCoordinator::with_defaults();
+        let pool = TransportPool::<HttpTarget>::new();
+        coordinator.set_http_pool(pool);
+
+        let target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:1",
+        ))
+        .unwrap();
+        let id = target.id().clone();
+
+        coordinator.add_http_target(target);
+
+        let pool = coordinator.http_pool().unwrap();
+        assert_eq!(pool.len(), 1);
+        assert!(pool.get_target(&id).is_some());
+    }
+
+    #[test]
+    fn test_add_http_target_no_pool() {
+        let coordinator = TransportCoordinator::with_defaults();
+        let target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:1",
+        ))
+        .unwrap();
+        // Should not panic when no pool is configured
+        coordinator.add_http_target(target);
+    }
+
+    #[test]
+    fn test_remove_http_target() {
+        let mut coordinator = TransportCoordinator::with_defaults();
+        let pool = TransportPool::<HttpTarget>::new();
+        coordinator.set_http_pool(pool);
+
+        let target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:1",
+        ))
+        .unwrap();
+        let id = target.id().clone();
+        coordinator.add_http_target(target);
+
+        assert!(coordinator.remove_http_target(&id));
+        assert!(!coordinator.remove_http_target(&id)); // Already removed
+        assert_eq!(coordinator.http_pool().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_remove_http_target_no_pool() {
+        let coordinator = TransportCoordinator::with_defaults();
+        let id = TargetId::http("http://localhost:1");
+        assert!(!coordinator.remove_http_target(&id));
+    }
+
+    #[test]
+    fn test_replace_http_target() {
+        let mut coordinator = TransportCoordinator::with_defaults();
+        let pool = TransportPool::<HttpTarget>::new();
+        coordinator.set_http_pool(pool);
+
+        let target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:1",
+        ))
+        .unwrap();
+        let old_id = target.id().clone();
+        coordinator.add_http_target(target);
+
+        let new_target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:2",
+        ))
+        .unwrap();
+        let new_id = new_target.id().clone();
+
+        assert!(coordinator.replace_http_target(&old_id, new_target));
+
+        let pool = coordinator.http_pool().unwrap();
+        assert_eq!(pool.len(), 1);
+        assert!(pool.get_target(&old_id).is_none());
+        assert!(pool.get_target(&new_id).is_some());
+    }
+
+    #[test]
+    fn test_replace_http_target_nonexistent() {
+        let mut coordinator = TransportCoordinator::with_defaults();
+        let pool = TransportPool::<HttpTarget>::new();
+        coordinator.set_http_pool(pool);
+
+        let old_id = TargetId::http("http://nonexistent:1");
+        let new_target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:2",
+        ))
+        .unwrap();
+
+        // Returns false because old target didn't exist, but still adds new one
+        assert!(!coordinator.replace_http_target(&old_id, new_target));
+        assert_eq!(coordinator.http_pool().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_replace_http_target_no_pool() {
+        let coordinator = TransportCoordinator::with_defaults();
+        let old_id = TargetId::http("http://localhost:1");
+        let new_target = HttpTarget::new(crate::http_target::HttpTargetConfig::stable(
+            "http://localhost:2",
+        ))
+        .unwrap();
+        assert!(!coordinator.replace_http_target(&old_id, new_target));
+    }
+
+    #[test]
+    fn test_http_pool_accessor() {
+        let coordinator = TransportCoordinator::with_defaults();
+        assert!(coordinator.http_pool().is_none());
+
+        let mut coordinator = TransportCoordinator::with_defaults();
+        coordinator.set_http_pool(TransportPool::<HttpTarget>::new());
+        assert!(coordinator.http_pool().is_some());
+    }
+
+    // ========================================================================
+    // CAPABILITY-FILTERED QUORUM TESTS
+    // ========================================================================
+
+    #[test]
+    fn test_quorum_target_count_uses_capabilities() {
+        use crate::http_target::HttpTargetConfig;
+
+        let mut coordinator = TransportCoordinator::with_defaults();
+        let pool = TransportPool::<HttpTarget>::new();
+
+        // Stable target: has QUORUM_CREDIT by default
+        pool.add_target(HttpTarget::new(HttpTargetConfig::stable("http://stable:1")).unwrap());
+
+        // Ephemeral target: no QUORUM_CREDIT by default
+        pool.add_target(
+            HttpTarget::new(HttpTargetConfig::ephemeral("http://ephemeral:1")).unwrap(),
+        );
+
+        // Ephemeral target with QUORUM_CREDIT override
+        let mut config = HttpTargetConfig::ephemeral("http://ephemeral-quorum:1");
+        config.base.capabilities = TargetCapabilities {
+            send: true,
+            quorum_credit: true,
+            ..TargetCapabilities::ephemeral_defaults()
+        };
+        pool.add_target(HttpTarget::new(config).unwrap());
+
+        coordinator.set_http_pool(pool);
+
+        let delivery_config = TieredDeliveryConfig::default();
+        // Should count 2: stable (has QUORUM_CREDIT) + ephemeral-quorum (override)
+        assert_eq!(coordinator.quorum_target_count(&delivery_config), 2);
+    }
+
+    #[test]
+    fn test_quorum_target_ids_uses_capabilities() {
+        use crate::http_target::HttpTargetConfig;
+
+        let mut coordinator = TransportCoordinator::with_defaults();
+        let pool = TransportPool::<HttpTarget>::new();
+
+        let stable = HttpTarget::new(HttpTargetConfig::stable("http://stable:1")).unwrap();
+        let stable_id = stable.id().clone();
+        pool.add_target(stable);
+
+        // Ephemeral: no QUORUM_CREDIT
+        pool.add_target(
+            HttpTarget::new(HttpTargetConfig::ephemeral("http://ephemeral:1")).unwrap(),
+        );
+
+        coordinator.set_http_pool(pool);
+
+        let delivery_config = TieredDeliveryConfig::default();
+        let ids = coordinator.quorum_target_ids(&delivery_config);
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0], stable_id);
     }
 
     #[tokio::test]

--- a/crates/reme-transport/src/pool.rs
+++ b/crates/reme-transport/src/pool.rs
@@ -14,7 +14,7 @@ use tracing::{debug, warn};
 
 use crate::query::{HealthSummary, TargetSnapshot, TransportQuery};
 use crate::seen_cache::SharedSeenCache;
-use crate::target::{HealthState, TargetId, TargetKind, TransportTarget};
+use crate::target::{HealthState, TargetCapabilities, TargetId, TargetKind, TransportTarget};
 use crate::{Transport, TransportError};
 
 /// Strategy for selecting and routing to targets in a pool.
@@ -135,6 +135,20 @@ impl<T: TransportTarget + 'static> TransportPool<T> {
         targets.len() < before_len
     }
 
+    /// Atomically remove a target by ID and add a replacement.
+    ///
+    /// Both operations happen under a single write lock so concurrent
+    /// readers never see a state with neither target present.
+    /// Returns `true` if the old target was found and removed.
+    pub fn replace_target(&self, old_id: &TargetId, new_target: T) -> bool {
+        let mut targets = self.targets.write().unwrap();
+        let before_len = targets.len();
+        targets.retain(|t| t.id() != old_id);
+        let removed = targets.len() < before_len;
+        targets.push(Arc::new(new_target));
+        removed
+    }
+
     /// Get all targets.
     pub fn all_targets(&self) -> Vec<Arc<T>> {
         self.targets.read().unwrap().clone()
@@ -158,6 +172,17 @@ impl<T: TransportTarget + 'static> TransportPool<T> {
             .unwrap()
             .iter()
             .filter(|t| t.config().kind == kind)
+            .cloned()
+            .collect()
+    }
+
+    /// Get targets matching a capability predicate.
+    pub fn targets_where(&self, pred: impl Fn(&TargetCapabilities) -> bool) -> Vec<Arc<T>> {
+        self.targets
+            .read()
+            .unwrap()
+            .iter()
+            .filter(|t| pred(&t.config().capabilities))
             .cloned()
             .collect()
     }
@@ -617,13 +642,30 @@ impl TransportPool<HttpTarget> {
     }
 
     /// Fetch from a specific set of targets.
+    ///
+    /// Only targets with the `FETCH` capability are included. Targets without
+    /// this capability (e.g., ephemeral peers) are skipped to avoid exposing
+    /// routing keys to untrusted nodes.
     async fn fetch_from_targets(
         &self,
         targets: &[Arc<HttpTarget>],
         routing_key: &RoutingKey,
     ) -> Result<Vec<OuterEnvelope>, TransportError> {
-        // Fetch from all targets in parallel
-        let futures: Vec<_> = targets
+        // Filter to only targets with FETCH capability
+        let fetchable: Vec<_> = targets
+            .iter()
+            .filter(|t| t.config().capabilities.fetch)
+            .cloned()
+            .collect();
+
+        if fetchable.is_empty() {
+            return Err(TransportError::Network(
+                "No fetchable targets available".to_string(),
+            ));
+        }
+
+        // Fetch from fetchable targets in parallel
+        let futures: Vec<_> = fetchable
             .iter()
             .map(|t| {
                 let t = t.clone();
@@ -646,11 +688,11 @@ impl TransportPool<HttpTarget> {
                     crate::dedup::merge_envelopes(
                         &mut accumulated,
                         messages,
-                        targets[i].id().as_str(),
+                        fetchable[i].id().as_str(),
                     );
                 }
                 Err(e) => {
-                    warn!("Target {} fetch failed: {}", targets[i].id(), e);
+                    warn!("Target {} fetch failed: {}", fetchable[i].id(), e);
                     last_error = Some(e);
                 }
             }
@@ -663,7 +705,7 @@ impl TransportPool<HttpTarget> {
                 "Fetched {} unique messages from {}/{} targets",
                 messages.len(),
                 success_count,
-                targets.len()
+                fetchable.len()
             );
             Ok(messages)
         } else {
@@ -755,5 +797,54 @@ mod tests {
 
         pool.add_target(create_test_target("http://localhost:1"));
         assert!(pool.has_available());
+    }
+
+    // ========================================================================
+    // CAPABILITY-FILTERED FETCH TESTS
+    // ========================================================================
+
+    #[tokio::test]
+    async fn test_fetch_skips_non_fetchable_targets() {
+        let pool: TransportPool<HttpTarget> = TransportPool::new();
+
+        // Ephemeral target: SEND only, no FETCH capability
+        pool.add_target(
+            HttpTarget::new(HttpTargetConfig::ephemeral("http://ephemeral:1")).unwrap(),
+        );
+
+        let routing_key = reme_message::RoutingKey::from_bytes([1u8; 16]);
+        let result = pool.fetch_once(&routing_key).await;
+
+        // Should fail because the only target lacks FETCH capability
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("No fetchable targets"),
+            "Expected 'No fetchable targets' error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_fetch_includes_fetchable_targets() {
+        let pool: TransportPool<HttpTarget> = TransportPool::new();
+
+        // Stable target: has FETCH capability by default
+        pool.add_target(HttpTarget::new(HttpTargetConfig::stable("http://stable:1")).unwrap());
+
+        // Ephemeral target: no FETCH capability
+        pool.add_target(
+            HttpTarget::new(HttpTargetConfig::ephemeral("http://ephemeral:1")).unwrap(),
+        );
+
+        let routing_key = reme_message::RoutingKey::from_bytes([1u8; 16]);
+        // This will fail with a network error (targets aren't real),
+        // but the error should NOT be "No fetchable targets" since the stable target is fetchable.
+        let result = pool.fetch_once(&routing_key).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            !err.contains("No fetchable targets"),
+            "Should have attempted fetch from stable target, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Add runtime target management methods to `TransportCoordinator`: `add_http_target()`, `remove_http_target()`, `update_http_target()`, and `http_pool()` accessor
- Add `targets_by_capability()` to `TransportPool` for filtering targets by capability flags
- Filter `fetch_from_targets()` to only include targets with `FETCH` capability (privacy: avoids exposing routing keys to ephemeral peers)
- Migrate quorum target selection from `TargetKind::Stable` to `TargetCapabilities::QUORUM_CREDIT` across `quorum_target_count()`, `quorum_target_ids()`, and `submit_to_quorum_targets()`