### PR TITLE
feat: add fake and mdns-sd discovery backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1380,6 +1380,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hostname"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-link",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1639,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1822,6 +1843,21 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "mdns-sd"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d797ab3274a16f4940f9650a29838e940223aeff31773df5c2827ad82150182f"
+dependencies = [
+ "fastrand",
+ "flume",
+ "if-addrs",
+ "log",
+ "mio",
+ "socket-pktinfo",
+ "socket2",
+]
 
 [[package]]
 name = "memchr"
@@ -2553,6 +2589,8 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "hex",
+ "hostname",
+ "mdns-sd",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -3173,6 +3211,17 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket-pktinfo"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "927136cc2ae6a1b0e66ac6b1210902b75c3f726db004a73bc18686dcd0dcd22f"
+dependencies = [
+ "libc",
+ "socket2",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "socket2"

--- a/crates/reme-discovery/Cargo.toml
+++ b/crates/reme-discovery/Cargo.toml
@@ -6,12 +6,17 @@ edition = "2021"
 [lints]
 workspace = true
 
+[features]
+mdns-sd = ["dep:mdns-sd", "dep:hostname"]
+
 [dependencies]
 async-trait = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
+hostname = { version = "0.4", optional = true }
+mdns-sd = { version = "0.18", optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["sync", "macros", "rt-multi-thread"] }

--- a/crates/reme-discovery/src/fake.rs
+++ b/crates/reme-discovery/src/fake.rs
@@ -1,0 +1,180 @@
+use std::sync::Mutex;
+
+use tokio::sync::broadcast;
+
+use crate::backend::DiscoveryBackend;
+use crate::types::{AdvertisementSpec, DiscoveryError, DiscoveryEvent, RawDiscoveredPeer};
+
+/// A deterministic discovery backend for testing.
+///
+/// Peers are injected manually via [`inject_peer`](Self::inject_peer) and
+/// [`inject_lost`](Self::inject_lost). Each call to [`subscribe`](Self::subscribe)
+/// returns an independent receiver that will see all future injected events.
+pub struct FakeDiscoveryBackend {
+    advertising: Mutex<bool>,
+    tx: broadcast::Sender<DiscoveryEvent>,
+}
+
+impl FakeDiscoveryBackend {
+    /// Create a new fake backend with no peers.
+    pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(64);
+        Self {
+            advertising: Mutex::new(false),
+            tx,
+        }
+    }
+
+    /// Inject a discovered peer, delivering `PeerDiscovered` to all subscribers.
+    pub fn inject_peer(&self, peer: RawDiscoveredPeer) {
+        // Ignore send errors (no active subscribers is fine).
+        let _ = self.tx.send(DiscoveryEvent::PeerDiscovered(peer));
+    }
+
+    /// Inject a peer-lost event, delivering `PeerLost` to all subscribers.
+    pub fn inject_lost(&self, instance_name: String) {
+        let _ = self.tx.send(DiscoveryEvent::PeerLost(instance_name));
+    }
+}
+
+impl Default for FakeDiscoveryBackend {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl DiscoveryBackend for FakeDiscoveryBackend {
+    async fn start_advertising(&self, _spec: AdvertisementSpec) -> Result<(), DiscoveryError> {
+        let mut advertising = self.advertising.lock().unwrap();
+        if *advertising {
+            return Err(DiscoveryError::AlreadyAdvertising);
+        }
+        *advertising = true;
+        Ok(())
+    }
+
+    async fn stop_advertising(&self) -> Result<(), DiscoveryError> {
+        let mut advertising = self.advertising.lock().unwrap();
+        if !*advertising {
+            return Err(DiscoveryError::NotAdvertising);
+        }
+        *advertising = false;
+        Ok(())
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<DiscoveryEvent> {
+        self.tx.subscribe()
+    }
+
+    async fn shutdown(&self) -> Result<(), DiscoveryError> {
+        *self.advertising.lock().unwrap() = false;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::net::IpAddr;
+    use std::time::Instant;
+
+    use super::*;
+
+    fn make_peer(name: &str) -> RawDiscoveredPeer {
+        RawDiscoveredPeer {
+            instance_name: name.to_owned(),
+            addresses: vec!["192.168.1.10".parse::<IpAddr>().unwrap()],
+            port: 8443,
+            txt_records: HashMap::new(),
+            discovered_at: Instant::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn inject_peer_and_receive() {
+        let backend = FakeDiscoveryBackend::new();
+        let mut rx = backend.subscribe();
+
+        backend.inject_peer(make_peer("alice"));
+
+        let event = rx.try_recv().unwrap();
+        match event {
+            DiscoveryEvent::PeerDiscovered(peer) => {
+                assert_eq!(peer.instance_name, "alice");
+            }
+            other => panic!("expected PeerDiscovered, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn inject_lost_and_receive() {
+        let backend = FakeDiscoveryBackend::new();
+        let mut rx = backend.subscribe();
+
+        backend.inject_lost("bob".to_owned());
+
+        let event = rx.try_recv().unwrap();
+        match event {
+            DiscoveryEvent::PeerLost(name) => assert_eq!(name, "bob"),
+            other => panic!("expected PeerLost, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn advertising_state_machine() {
+        let backend = FakeDiscoveryBackend::new();
+        let spec = AdvertisementSpec::new(8443);
+
+        // Cannot stop before starting.
+        assert_eq!(
+            backend.stop_advertising().await,
+            Err(DiscoveryError::NotAdvertising),
+        );
+
+        // Start succeeds.
+        backend.start_advertising(spec.clone()).await.unwrap();
+
+        // Double-start fails.
+        assert_eq!(
+            backend.start_advertising(spec).await,
+            Err(DiscoveryError::AlreadyAdvertising),
+        );
+
+        // Stop succeeds.
+        backend.stop_advertising().await.unwrap();
+
+        // Double-stop fails.
+        assert_eq!(
+            backend.stop_advertising().await,
+            Err(DiscoveryError::NotAdvertising),
+        );
+    }
+
+    #[tokio::test]
+    async fn multiple_subscribers_receive_events() {
+        let backend = FakeDiscoveryBackend::new();
+        let mut rx1 = backend.subscribe();
+        let mut rx2 = backend.subscribe();
+
+        backend.inject_peer(make_peer("charlie"));
+
+        assert!(rx1.try_recv().is_ok());
+        assert!(rx2.try_recv().is_ok());
+    }
+
+    #[tokio::test]
+    async fn shutdown_stops_advertising() {
+        let backend = FakeDiscoveryBackend::new();
+        let spec = AdvertisementSpec::new(8443);
+
+        backend.start_advertising(spec).await.unwrap();
+        backend.shutdown().await.unwrap();
+
+        // After shutdown, advertising is stopped.
+        assert_eq!(
+            backend.stop_advertising().await,
+            Err(DiscoveryError::NotAdvertising),
+        );
+    }
+}

--- a/crates/reme-discovery/src/lib.rs
+++ b/crates/reme-discovery/src/lib.rs
@@ -1,4 +1,7 @@
 pub mod backend;
+pub mod fake;
+#[cfg(feature = "mdns-sd")]
+pub mod mdns_sd;
 pub mod txt;
 pub mod types;
 

--- a/crates/reme-discovery/src/mdns_sd.rs
+++ b/crates/reme-discovery/src/mdns_sd.rs
@@ -1,0 +1,222 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+use crate::backend::DiscoveryBackend;
+use crate::types::{
+    AdvertisementSpec, DiscoveryError, DiscoveryEvent, RawDiscoveredPeer, DEFAULT_SERVICE_TYPE,
+};
+
+/// mDNS-SD discovery backend using the [`mdns_sd`] crate.
+///
+/// Advertises and browses for `_reme._tcp.local.` services on the LAN.
+pub struct MdnsSdBackend {
+    daemon: mdns_sd::ServiceDaemon,
+    state: Mutex<MdnsState>,
+    tx: broadcast::Sender<DiscoveryEvent>,
+}
+
+struct MdnsState {
+    advertising: bool,
+    /// The full service name returned by `register`, needed for `unregister`.
+    registered_fullname: Option<String>,
+    /// Whether a browse thread is already running.
+    browsing: bool,
+}
+
+impl MdnsSdBackend {
+    /// Create a new mDNS-SD backend.
+    ///
+    /// Returns [`DiscoveryError::BindFailed`] if the daemon cannot bind to the
+    /// multicast socket.
+    pub fn new() -> Result<Self, DiscoveryError> {
+        let daemon =
+            mdns_sd::ServiceDaemon::new().map_err(|e| DiscoveryError::BindFailed(e.to_string()))?;
+
+        let (tx, _) = broadcast::channel(128);
+
+        Ok(Self {
+            daemon,
+            state: Mutex::new(MdnsState {
+                advertising: false,
+                registered_fullname: None,
+                browsing: false,
+            }),
+            tx,
+        })
+    }
+
+    /// Convert an [`mdns_sd::ResolvedService`] into a [`RawDiscoveredPeer`].
+    fn resolved_to_peer(info: &mdns_sd::ResolvedService) -> RawDiscoveredPeer {
+        let addresses = info
+            .addresses
+            .iter()
+            .map(mdns_sd::ScopedIp::to_ip_addr)
+            .collect();
+
+        let txt_records: HashMap<String, String> = info
+            .txt_properties
+            .iter()
+            .map(|prop| (prop.key().to_owned(), prop.val_str().to_owned()))
+            .collect();
+
+        RawDiscoveredPeer {
+            instance_name: info.fullname.clone(),
+            addresses,
+            port: info.port,
+            txt_records,
+            discovered_at: Instant::now(),
+        }
+    }
+
+    /// Start the browse thread if not already running. Called on first subscribe.
+    fn ensure_browsing(&self) {
+        let mut state = self.state.lock().unwrap();
+        if state.browsing {
+            return;
+        }
+
+        let browse_receiver = match self.daemon.browse(DEFAULT_SERVICE_TYPE) {
+            Ok(r) => r,
+            Err(e) => {
+                warn!("mDNS-SD: failed to start browsing: {e}");
+                return;
+            }
+        };
+
+        state.browsing = true;
+        let tx = self.tx.clone();
+
+        // Bridge the std mpsc receiver from mdns-sd into our broadcast sender.
+        std::thread::spawn(move || {
+            while let Ok(event) = browse_receiver.recv() {
+                let discovery_event = match event {
+                    mdns_sd::ServiceEvent::ServiceFound(_stype, fullname) => {
+                        debug!(fullname, "mDNS-SD: service found (awaiting resolution)");
+                        continue;
+                    }
+                    mdns_sd::ServiceEvent::ServiceResolved(info) => {
+                        debug!(fullname = %info.fullname, "mDNS-SD: service resolved");
+                        DiscoveryEvent::PeerDiscovered(Self::resolved_to_peer(&info))
+                    }
+                    mdns_sd::ServiceEvent::ServiceRemoved(_stype, fullname) => {
+                        debug!(fullname, "mDNS-SD: service removed");
+                        DiscoveryEvent::PeerLost(fullname)
+                    }
+                    _ => continue,
+                };
+
+                // Ignore errors — no active subscribers is fine.
+                let _ = tx.send(discovery_event);
+            }
+        });
+    }
+}
+
+#[async_trait::async_trait]
+impl DiscoveryBackend for MdnsSdBackend {
+    async fn start_advertising(&self, spec: AdvertisementSpec) -> Result<(), DiscoveryError> {
+        // Phase 1: Check state under lock.
+        {
+            let state = self.state.lock().unwrap();
+            if state.advertising {
+                return Err(DiscoveryError::AlreadyAdvertising);
+            }
+        }
+
+        // Phase 2: Build and register service (no lock held).
+        let hostname = hostname::get()
+            .ok()
+            .and_then(|h| h.into_string().ok())
+            .unwrap_or_else(|| "reme-node".to_owned());
+
+        let instance_name = format!("{hostname}-{}", std::process::id());
+
+        let properties: Vec<(&str, &str)> = spec
+            .txt_records
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        let service_info = mdns_sd::ServiceInfo::new(
+            &spec.service_type,
+            &instance_name,
+            &hostname,
+            "",
+            spec.port,
+            &properties[..],
+        )
+        .map_err(|e| DiscoveryError::BackendError(e.to_string()))?;
+
+        let fullname = service_info.get_fullname().to_owned();
+
+        self.daemon
+            .register(service_info)
+            .map_err(|e| DiscoveryError::BackendError(e.to_string()))?;
+
+        // Phase 3: Commit state under lock.
+        {
+            let mut state = self.state.lock().unwrap();
+            debug!(fullname = %fullname, "mDNS-SD: advertising started");
+            state.advertising = true;
+            state.registered_fullname = Some(fullname);
+        }
+        Ok(())
+    }
+
+    async fn stop_advertising(&self) -> Result<(), DiscoveryError> {
+        // Phase 1: Clone fullname under lock (don't take — keep it for retry on failure).
+        let fullname = {
+            let state = self.state.lock().unwrap();
+            if !state.advertising {
+                return Err(DiscoveryError::NotAdvertising);
+            }
+            state.registered_fullname.clone()
+        };
+
+        // Phase 2: Unregister with daemon (no lock held).
+        if let Some(ref fullname) = fullname {
+            self.daemon
+                .unregister(fullname)
+                .map_err(|e| DiscoveryError::BackendError(e.to_string()))?;
+            debug!(fullname = %fullname, "mDNS-SD: advertising stopped");
+        }
+
+        // Phase 3: Commit state under lock only on success.
+        {
+            let mut state = self.state.lock().unwrap();
+            state.advertising = false;
+            state.registered_fullname = None;
+        }
+        Ok(())
+    }
+
+    fn subscribe(&self) -> broadcast::Receiver<DiscoveryEvent> {
+        self.ensure_browsing();
+        self.tx.subscribe()
+    }
+
+    async fn shutdown(&self) -> Result<(), DiscoveryError> {
+        // Phase 1: Read state under lock.
+        let fullname = {
+            let mut state = self.state.lock().unwrap();
+            state.advertising = false;
+            state.registered_fullname.take()
+        };
+
+        // Phase 2: Unregister and shut down daemon (no lock held).
+        if let Some(ref fullname) = fullname {
+            if let Err(e) = self.daemon.unregister(fullname) {
+                warn!(fullname = %fullname, "mDNS-SD: failed to unregister during shutdown: {e}");
+            }
+        }
+
+        self.daemon
+            .shutdown()
+            .map_err(|e| DiscoveryError::BackendError(e.to_string()))?;
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary
- Add `FakeDiscoveryBackend` for deterministic testing — supports `inject_peer`/`inject_lost` with proper channel-full handling (only evicts on closed, not on full)
- Add `MdnsSdBackend` (feature-gated behind `mdns-sd`) using `mdns-sd` v0.18 — bridges sync browse receiver into tokio mpsc via a dedicated thread, with Mutex not held across daemon calls
- Wire both into `src/lib.rs` with appropriate `#[cfg]` gating