### PR TITLE
docs: consolidate AGENTS.md for actionable agent context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,5 +141,5 @@ Research/prototype stage — no external users. Breaking changes and public API 
 
 - [ ] `cargo fmt --all -- --check` — formatting
 - [ ] `cargo clippy --all-targets --all-features -- -D warnings` — linting
-- [ ] `cargo test` — all tests pass
+- [ ] `cargo test --workspace --all-features --all-targets` — all tests pass
 - [ ] No new `unwrap()` in library crates (use proper error handling)


### PR DESCRIPTION
## Summary

- Trimmed verbose crypto documentation, config TOML examples, external references, and "Why Not X3DH" section — content better suited for docs/ than agent instructions
- Added missing `reme-config` crate to architecture diagram
- Added `cargo fmt` and `cargo clippy` to build commands section
- Added project phase note (research stage, breaking changes encouraged)
- Added pre-commit checklist with formatting, linting, tests, and error handling rules
- Fixed header from `# CLAUDE.md` to `# AGENTS.md` with agent-agnostic description

Net reduction: **247 → 145 lines** (42% smaller) while retaining all actionable information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed and reorganized the main guidance document with clearer, concise wording.
  * Replaced lengthy technical rationale with focused summaries, checklists, and a project-phase note (research/prototype tone).
  * Consolidated build commands into a compact block and added a pre-commit checklist for formatting, linting, and tests.
  * Streamlined crypto, transport auth, and tombstone explanations into concise summaries; added wire format notes and updated testing pattern guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->