### PR TITLE
feat: add channel binding to identity verification

### DIFF
--- a/apps/client/src/discovery/controller.rs
+++ b/apps/client/src/discovery/controller.rs
@@ -347,7 +347,7 @@ impl DiscoveryController {
         };
 
         for candidate in candidates {
-            let sign_data = build_identity_sign_data(&challenge, &candidate.to_bytes());
+            let sign_data = build_identity_sign_data(&challenge, &candidate.to_bytes(), None);
             if candidate.verify_xeddsa(&sign_data, &signature) {
                 return Ok(Some(*candidate));
             }

--- a/apps/client/src/tui/http_server.rs
+++ b/apps/client/src/tui/http_server.rs
@@ -453,7 +453,7 @@ async fn get_identity(
         // Note: node_pubkey is still included in signed data for cryptographic binding,
         // but not returned in response (privacy: prevents identity enumeration)
         let node_pubkey = identity.public_id().to_bytes();
-        let sign_data = build_identity_sign_data(&challenge, &node_pubkey);
+        let sign_data = build_identity_sign_data(&challenge, &node_pubkey, None);
         let signature = identity.sign_xeddsa(&sign_data);
 
         IdentityResponse {
@@ -1151,7 +1151,7 @@ mod tests {
 
         // Reconstruct signed data using helper and known pubkey
         let node_pubkey = identity_pubkey.to_bytes();
-        let sign_data = build_identity_sign_data(&challenge, &node_pubkey);
+        let sign_data = build_identity_sign_data(&challenge, &node_pubkey, None);
 
         assert!(
             identity_pubkey.verify_xeddsa(&sign_data, &signature),

--- a/apps/node/src/api.rs
+++ b/apps/node/src/api.rs
@@ -83,18 +83,24 @@ pub fn router(state: Arc<AppState>, rate_limiters: Option<&RateLimiters>) -> Rou
         fetch_route
     };
 
-    // Combine routes with shared middleware
-    Router::new()
+    // Routes that require Basic Auth (when configured)
+    let authenticated_routes = Router::new()
         .merge(submit_route)
         .merge(fetch_route)
         .route("/api/v1/health", get(health_check))
         .route("/api/v1/stats", get(get_stats))
-        .route("/api/v1/identity", get(get_identity))
-        .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             check_basic_auth,
-        ))
+        ));
+
+    // Routes exempt from Basic Auth (unauthenticated LAN peers need identity verification)
+    let public_routes = Router::new().route("/api/v1/identity", get(get_identity));
+
+    Router::new()
+        .merge(authenticated_routes)
+        .merge(public_routes)
+        .layer(DefaultBodyLimit::max(MAX_BODY_SIZE))
         .with_state(state)
 }
 
@@ -908,7 +914,7 @@ async fn get_identity(
         // Note: node_pubkey is still included in signed data for cryptographic binding,
         // but not returned in response (privacy: prevents identity enumeration)
         let node_pubkey = identity.public_id().to_bytes();
-        let sign_data = build_identity_sign_data(&challenge, &node_pubkey);
+        let sign_data = build_identity_sign_data(&challenge, &node_pubkey, None);
         let signature = identity.sign(&sign_data);
 
         IdentityResponse {

--- a/apps/node/tests/identity_endpoint.rs
+++ b/apps/node/tests/identity_endpoint.rs
@@ -149,7 +149,7 @@ async fn test_valid_challenge_returns_valid_response() {
         .expect("Wrong signature length");
 
     // Reconstruct signed data using shared helper and known pubkey
-    let sign_data = build_identity_sign_data(&challenge, &node_pubkey.to_bytes());
+    let sign_data = build_identity_sign_data(&challenge, &node_pubkey.to_bytes(), None);
 
     assert!(
         node_pubkey.verify_xeddsa(&sign_data, &signature),
@@ -328,8 +328,8 @@ async fn test_signature_is_challenge_specific() {
 
     // Verify both signatures using the known public key
     let node_pubkey_bytes = node_pubkey.to_bytes();
-    let sign_data1 = build_identity_sign_data(&challenge1, &node_pubkey_bytes);
-    let sign_data2 = build_identity_sign_data(&challenge2, &node_pubkey_bytes);
+    let sign_data1 = build_identity_sign_data(&challenge1, &node_pubkey_bytes, None);
+    let sign_data2 = build_identity_sign_data(&challenge2, &node_pubkey_bytes, None);
 
     assert!(
         node_pubkey.verify_xeddsa(&sign_data1, &signature1),

--- a/crates/reme-encryption/src/lib.rs
+++ b/crates/reme-encryption/src/lib.rs
@@ -365,19 +365,43 @@ pub fn build_receipt_sign_data(signer_pubkey: &[u8; 32], message_id: &MessageID)
 
 /// Build the data to be signed for identity verification.
 ///
-/// Format: `"reme-identity-v1:" || challenge || node_pubkey`
+/// Format: `"reme-identity-v1:" || bound_challenge || node_pubkey`
 ///
 /// Used by both nodes (to sign) and clients (to verify) in the identity
 /// challenge-response protocol.
 ///
+/// When `channel` is provided, the challenge is mixed with the channel bytes
+/// via BLAKE3 to produce a channel-bound challenge. This prevents relay attacks
+/// where a malicious peer forwards identity challenges to the real peer and
+/// replays the response. Both signer and verifier must agree on the channel
+/// value for verification to succeed.
+///
+/// When `channel` is `None`, the original challenge is used as-is for backward
+/// compatibility.
+///
 /// # Arguments
 /// * `challenge` - 32-byte random challenge from the verifier
 /// * `node_pubkey` - 32-byte X25519 public key of the node
-pub fn build_identity_sign_data(challenge: &[u8; 32], node_pubkey: &[u8; 32]) -> [u8; 81] {
-    // Layout: "reme-identity-v1:" (17) || challenge (32) || node_pubkey (32) = 81 bytes
+/// * `channel` - Optional responder address (e.g. `b"192.168.1.50:23003"`) for
+///   channel binding
+pub fn build_identity_sign_data(
+    challenge: &[u8; 32],
+    node_pubkey: &[u8; 32],
+    channel: Option<&[u8]>,
+) -> [u8; 81] {
+    let bound_challenge = if let Some(channel_bytes) = channel {
+        let mut hasher = blake3::Hasher::new_derive_key("reme-channel-bind-v0");
+        hasher.update(challenge);
+        hasher.update(channel_bytes);
+        *hasher.finalize().as_bytes()
+    } else {
+        *challenge
+    };
+
+    // Layout: "reme-identity-v1:" (17) || bound_challenge (32) || node_pubkey (32) = 81 bytes
     let mut sign_data = [0u8; 81];
     sign_data[..17].copy_from_slice(IDENTITY_SIGN_DOMAIN);
-    sign_data[17..49].copy_from_slice(challenge);
+    sign_data[17..49].copy_from_slice(&bound_challenge);
     sign_data[49..].copy_from_slice(node_pubkey);
     sign_data
 }
@@ -453,6 +477,7 @@ pub struct DecryptionOutput {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand_core::RngCore;
     use reme_identity::Identity;
     use reme_message::{Content, TextContent};
 
@@ -1017,6 +1042,99 @@ mod tests {
         assert!(
             !verify_receipt_signature(&node_public, &message_id, &signature),
             "Tampered receipt signature should not verify"
+        );
+    }
+
+    #[test]
+    fn test_identity_sign_data_channel_binding_matching() {
+        let mut challenge = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut challenge);
+        let node = Identity::generate();
+        let node_pubkey = node.public_id().to_bytes();
+        let channel = b"192.168.1.50:23003";
+
+        // Sign with channel
+        let sign_data = build_identity_sign_data(&challenge, &node_pubkey, Some(channel));
+        let signature = node.sign_xeddsa(&sign_data);
+
+        // Verify with same channel should succeed
+        let verify_data = build_identity_sign_data(&challenge, &node_pubkey, Some(channel));
+        assert!(
+            node.public_id().verify_xeddsa(&verify_data, &signature),
+            "Channel-bound signature should verify with matching channel"
+        );
+    }
+
+    #[test]
+    fn test_identity_sign_data_channel_binding_mismatch() {
+        let mut challenge = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut challenge);
+        let node = Identity::generate();
+        let node_pubkey = node.public_id().to_bytes();
+
+        // Sign with one channel
+        let sign_data =
+            build_identity_sign_data(&challenge, &node_pubkey, Some(b"192.168.1.50:23003"));
+        let signature = node.sign_xeddsa(&sign_data);
+
+        // Verify with different channel should fail
+        let verify_data =
+            build_identity_sign_data(&challenge, &node_pubkey, Some(b"10.0.0.1:9999"));
+        assert!(
+            !node.public_id().verify_xeddsa(&verify_data, &signature),
+            "Channel-bound signature should NOT verify with different channel"
+        );
+    }
+
+    #[test]
+    fn test_identity_sign_data_none_channel_backward_compat() {
+        let mut challenge = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut challenge);
+        let node = Identity::generate();
+        let node_pubkey = node.public_id().to_bytes();
+
+        // Sign without channel (backward compat)
+        let sign_data = build_identity_sign_data(&challenge, &node_pubkey, None);
+        let signature = node.sign_xeddsa(&sign_data);
+
+        // Verify without channel should succeed
+        let verify_data = build_identity_sign_data(&challenge, &node_pubkey, None);
+        assert!(
+            node.public_id().verify_xeddsa(&verify_data, &signature),
+            "None-channel signature should verify with None channel"
+        );
+    }
+
+    #[test]
+    fn test_identity_sign_data_channel_vs_none_mismatch() {
+        let mut challenge = [0u8; 32];
+        rand_core::OsRng.fill_bytes(&mut challenge);
+        let node = Identity::generate();
+        let node_pubkey = node.public_id().to_bytes();
+
+        // Sign with channel
+        let sign_data =
+            build_identity_sign_data(&challenge, &node_pubkey, Some(b"192.168.1.50:23003"));
+        let signature = node.sign_xeddsa(&sign_data);
+
+        // Verify with None should fail (channel mismatch)
+        let verify_data = build_identity_sign_data(&challenge, &node_pubkey, None);
+        assert!(
+            !node.public_id().verify_xeddsa(&verify_data, &signature),
+            "Channel-bound signature should NOT verify without channel"
+        );
+
+        // And vice versa: sign with None, verify with channel
+        let sign_data_none = build_identity_sign_data(&challenge, &node_pubkey, None);
+        let signature_none = node.sign_xeddsa(&sign_data_none);
+
+        let verify_with_channel =
+            build_identity_sign_data(&challenge, &node_pubkey, Some(b"192.168.1.50:23003"));
+        assert!(
+            !node
+                .public_id()
+                .verify_xeddsa(&verify_with_channel, &signature_none),
+            "None-channel signature should NOT verify with channel"
         );
     }
 }

--- a/crates/reme-transport/src/http.rs
+++ b/crates/reme-transport/src/http.rs
@@ -247,7 +247,7 @@ impl HttpTransport {
 
         // Try each candidate until one verifies
         for candidate in candidates {
-            let sign_data = build_identity_sign_data(&challenge, &candidate.to_bytes());
+            let sign_data = build_identity_sign_data(&challenge, &candidate.to_bytes(), None);
             if candidate.verify_xeddsa(&sign_data, &signature) {
                 debug!("Verified identity for {}", candidate);
                 return Ok(Some(*candidate));
@@ -808,7 +808,7 @@ mod tests {
                     .try_into()
                     .expect("Challenge must be 32 bytes");
 
-                let sign_data = build_identity_sign_data(&challenge, &pubkey_bytes);
+                let sign_data = build_identity_sign_data(&challenge, &pubkey_bytes, None);
                 let signature = identity.sign_xeddsa(&sign_data);
 
                 async move {
@@ -876,7 +876,7 @@ mod tests {
                     .expect("Challenge must be 32 bytes");
 
                 // Sign with node's actual key (different from expected)
-                let sign_data = build_identity_sign_data(&challenge, &node_pubkey_bytes);
+                let sign_data = build_identity_sign_data(&challenge, &node_pubkey_bytes, None);
                 let signature = node_identity.sign_xeddsa(&sign_data);
 
                 async move {
@@ -945,7 +945,7 @@ mod tests {
                     .try_into()
                     .expect("Challenge must be 32 bytes");
 
-                let sign_data = build_identity_sign_data(&challenge, &pubkey_bytes);
+                let sign_data = build_identity_sign_data(&challenge, &pubkey_bytes, None);
                 let signature = identity.sign_xeddsa(&sign_data);
 
                 async move {


### PR DESCRIPTION
## Summary

- Adds optional `channel` parameter to `build_identity_sign_data()` that mixes responder address into challenge via BLAKE3
- All existing callers updated with `None` (backward compatible)
- Node identity endpoint exempted from Basic Auth for LAN discovery
- New tests for channel binding: matching/mismatching/None channels

Part of mDNS/LAN discovery (v0.4 roadmap, Unit 9). Split from #86.