### PR TITLE
feat: wire mDNS discovery into client runtime

### DIFF
--- a/apps/client/Cargo.toml
+++ b/apps/client/Cargo.toml
@@ -16,7 +16,7 @@ reme-storage = { workspace = true }
 reme-outbox = { workspace = true }
 reme-core = { workspace = true }
 reme-config = { workspace = true, features = ["http", "mqtt"] }
-reme-discovery = { workspace = true }
+reme-discovery = { workspace = true, features = ["mdns-sd"] }
 
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/apps/client/src/config.rs
+++ b/apps/client/src/config.rs
@@ -433,6 +433,14 @@ pub struct EmbeddedNodeConfig {
     pub default_ttl_secs: u64,
 }
 
+/// LAN discovery configuration for mDNS-based peer discovery.
+#[derive(Debug, Clone, Deserialize, Serialize, Default, PartialEq)]
+pub struct LanDiscoveryConfig {
+    /// Enable mDNS/LAN peer discovery (default: false).
+    #[serde(default)]
+    pub enabled: bool,
+}
+
 /// Direct peer configuration for LAN P2P messaging.
 ///
 /// Peers configured here are added as ephemeral targets with high priority,
@@ -480,6 +488,10 @@ pub struct AppConfig {
     /// Tiered delivery configuration
     #[serde(default)]
     pub delivery: DeliveryAppConfig,
+
+    /// LAN discovery configuration
+    #[serde(default)]
+    pub lan_discovery: LanDiscoveryConfig,
 }
 
 fn default_peers() -> PeersConfig {
@@ -510,6 +522,7 @@ impl Default for AppConfig {
             log_level: "info".to_string(),
             outbox: OutboxAppConfig::default(),
             delivery: DeliveryAppConfig::default(),
+            lan_discovery: LanDiscoveryConfig::default(),
         }
     }
 }
@@ -544,6 +557,9 @@ struct RawConfig {
     /// Delivery config section
     #[serde(default)]
     delivery: RawDeliveryConfig,
+    /// LAN discovery config section
+    #[serde(default)]
+    lan_discovery: Option<LanDiscoveryConfig>,
 }
 
 /// Raw outbox config from file/env
@@ -752,6 +768,9 @@ pub fn load_config() -> Result<AppConfig, config::ConfigError> {
     // Resolve direct peers from config file > defaults (empty)
     let direct_peers = raw.direct_peers.unwrap_or_default();
 
+    // Resolve LAN discovery config from config file > defaults
+    let lan_discovery = raw.lan_discovery.unwrap_or_default();
+
     Ok(AppConfig {
         peers,
         embedded_node,
@@ -760,6 +779,7 @@ pub fn load_config() -> Result<AppConfig, config::ConfigError> {
         log_level,
         outbox,
         delivery,
+        lan_discovery,
     })
 }
 
@@ -888,6 +908,12 @@ default_ttl_secs = {embedded_ttl_secs}
 # address = "http://192.168.1.101:23004"
 # name = "Bob (LAN)"                          # Optional
 # public_id = "BASE64_ENCODED_PUBLIC_ID"      # Optional, reserved for future
+
+# LAN discovery via mDNS (automatic peer discovery on local network)
+# When enabled, discovers peers via mDNS-SD and registers them as ephemeral targets.
+# Requires embedded_node with http_bind to advertise our own presence.
+# [lan_discovery]
+# enabled = true
 "#,
         url = defaults.peers.http[0].url,
         data_dir = defaults.data_dir.to_string_lossy(),
@@ -935,6 +961,7 @@ mod tests {
         assert!(!config.embedded_node.enabled);
         assert!(config.direct_peers.is_empty());
         assert_eq!(config.log_level, "info");
+        assert!(!config.lan_discovery.enabled);
     }
 
     #[test]
@@ -1182,5 +1209,32 @@ mod tests {
         assert_eq!(config.direct_peers[0].name, Some("Alice".to_string()));
         assert!(config.direct_peers[1].public_id.is_none());
         assert!(config.direct_peers[1].name.is_none());
+    }
+
+    #[test]
+    fn test_lan_discovery_config_default() {
+        let config = LanDiscoveryConfig::default();
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn test_lan_discovery_config_enabled() {
+        let toml = r"
+            [lan_discovery]
+            enabled = true
+        ";
+        let config: LanDiscoveryConfig = toml::from_str::<RawConfig>(toml)
+            .unwrap()
+            .lan_discovery
+            .unwrap();
+        assert!(config.enabled);
+    }
+
+    #[test]
+    fn test_lan_discovery_config_disabled_by_default_in_toml() {
+        let toml = "";
+        let raw: RawConfig = toml::from_str(toml).unwrap();
+        let config = raw.lan_discovery.unwrap_or_default();
+        assert!(!config.enabled);
     }
 }

--- a/apps/client/src/discovery/controller.rs
+++ b/apps/client/src/discovery/controller.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::Arc;
 
 use base64::prelude::*;
@@ -362,6 +362,7 @@ mod tests {
     use super::*;
     use reme_identity::Identity;
     use reme_transport::coordinator::CoordinatorConfig;
+    use std::net::IpAddr;
 
     #[test]
     fn socket_addr_formats_ipv6_with_brackets() {

--- a/apps/client/src/discovery/mod.rs
+++ b/apps/client/src/discovery/mod.rs
@@ -1,3 +1,1 @@
-// TODO(lan-discovery): Remove `allow` once the discovery controller is wired into the app.
-#[allow(dead_code, unused_imports)]
 pub mod controller;

--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -1,6 +1,7 @@
 //! Application state and main loop
 
 use crate::config::AppConfig;
+use crate::discovery;
 use crate::tui::event::{Event, EventHandler};
 use crate::tui::http_server;
 use crate::tui::ui;
@@ -9,6 +10,8 @@ use crossterm::execute;
 use ratatui::prelude::*;
 use reme_config::{ParsedHttpPeer, ParsedMqttPeer};
 use reme_core::Client;
+use reme_discovery::mdns_sd::MdnsSdBackend;
+use reme_discovery::DiscoveryBackend;
 use reme_identity::{Identity, PublicID};
 use reme_message::Content;
 use reme_node_core::{
@@ -29,6 +32,7 @@ use std::fs;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 use tui_textarea::{Input, TextArea};
 use zeroize::Zeroizing;
@@ -350,6 +354,12 @@ pub struct App<'a> {
     pub registry: TransportRegistry,
     /// Outbox tick interval from config
     outbox_tick_interval: Duration,
+    /// mDNS discovery backend (for shutdown)
+    discovery_backend: Option<Arc<MdnsSdBackend>>,
+    /// Discovery controller cancel token
+    discovery_cancel: Option<CancellationToken>,
+    /// Discovery controller task handle (for awaiting shutdown)
+    discovery_task: Option<tokio::task::JoinHandle<()>>,
 }
 
 impl App<'_> {
@@ -675,6 +685,70 @@ impl App<'_> {
             registry.register_stable(id, label, DeliveryTier::Direct);
         }
 
+        // --- LAN Discovery ---
+        let (discovery_backend, discovery_cancel, discovery_task) = if config.lan_discovery.enabled
+        {
+            match MdnsSdBackend::new() {
+                Ok(backend) => {
+                    // Build contact list for routing key matching
+                    let contacts: Vec<(PublicID, [u8; 16])> = storage
+                        .list_contacts()
+                        .unwrap_or_else(|e| {
+                            warn!("Failed to load contacts for discovery: {e}");
+                            Vec::new()
+                        })
+                        .into_iter()
+                        .map(|(_, pubkey, _)| {
+                            let rk: [u8; 16] = pubkey.routing_key().into();
+                            (pubkey, rk)
+                        })
+                        .collect();
+
+                    // Subscribe to discovery events
+                    let events = backend.subscribe();
+
+                    // Spawn discovery controller
+                    let cancel = CancellationToken::new();
+                    let controller_handle = discovery::controller::spawn(
+                        events,
+                        coordinator.clone(),
+                        contacts,
+                        cancel.clone(),
+                    );
+
+                    // Start advertising only if HTTP server is bound
+                    if let Some(ref http_bind) = config.embedded_node.http_bind {
+                        let port: u16 = http_bind
+                            .rsplit(':')
+                            .next()
+                            .and_then(|p| p.parse().ok())
+                            .unwrap_or(23004);
+
+                        let our_rk: [u8; 16] = identity.public_id().routing_key().into();
+                        let txt = reme_discovery::encode_txt(&our_rk, port, 1);
+                        let spec = reme_discovery::AdvertisementSpec {
+                            txt_records: txt,
+                            ..reme_discovery::AdvertisementSpec::new(port)
+                        };
+
+                        if let Err(e) = backend.start_advertising(spec).await {
+                            warn!("Failed to start mDNS advertising: {e}");
+                        }
+                    }
+
+                    info!("LAN discovery enabled");
+                    let backend = Arc::new(backend);
+                    (Some(backend), Some(cancel), Some(controller_handle))
+                }
+                Err(e) => {
+                    warn!("Failed to initialize mDNS backend: {e}. LAN discovery disabled.");
+                    (None, None, None)
+                }
+            }
+        } else {
+            (None, None, None)
+        };
+
         // Build OutboxConfig from app config
         let ttl_ms = if config.outbox.ttl_days == 0 {
             None
@@ -734,6 +808,9 @@ impl App<'_> {
             show_upstreams_popup: false,
             registry,
             outbox_tick_interval,
+            discovery_backend,
+            discovery_cancel,
+            discovery_task,
         };
 
         // Load contacts
@@ -853,10 +930,40 @@ impl App<'_> {
             }
         }
 
+        // Graceful shutdown of discovery
+        self.shutdown_discovery().await;
+
         // Graceful shutdown of embedded node
         self.shutdown_embedded_node().await;
 
         Ok(())
+    }
+
+    /// Shutdown the discovery subsystem gracefully.
+    ///
+    /// Cancels the discovery controller, awaits its task, then shuts down
+    /// the mDNS backend to release network resources.
+    async fn shutdown_discovery(&mut self) {
+        if let Some(cancel) = self.discovery_cancel.take() {
+            debug!("Cancelling discovery controller...");
+            cancel.cancel();
+        }
+
+        if let Some(task) = self.discovery_task.take() {
+            debug!("Waiting for discovery controller to stop...");
+            if let Err(e) = task.await {
+                warn!(error = %e, "Discovery controller task panicked during shutdown");
+            }
+        }
+
+        if let Some(backend) = self.discovery_backend.take() {
+            debug!("Shutting down mDNS backend...");
+            if let Err(e) = backend.shutdown().await {
+                warn!(error = %e, "Failed to shutdown mDNS backend");
+            } else {
+                info!("mDNS backend shutdown complete");
+            }
+        }
     }
 
     /// Shutdown the embedded node gracefully.


### PR DESCRIPTION
## Summary

- Adds `LanDiscoveryConfig` (with `enabled` flag) to the client config system
- Wires the mDNS-SD discovery backend and discovery controller into the TUI app startup, gated behind `lan_discovery.enabled`
- Advertises via mDNS only when `embedded_node.http_bind` is configured (so there is a reachable endpoint to advertise)
- Adds graceful shutdown: cancels the discovery controller token and shuts down the mDNS backend before the embedded node
- Removes the `dead_code`/`unused_imports` allow from the discovery module now that it is wired in
- Fixes an unused `IpAddr` import by moving it to test-only scope