### PR TITLE
fix: reject empty password in save_identity

### DIFF
--- a/crates/reme-identity/src/encrypted.rs
+++ b/crates/reme-identity/src/encrypted.rs
@@ -58,6 +58,7 @@ const ARGON2_P: u32 = 1; // 1 parallelism
 
 /// Errors that can occur during encrypted identity operations
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum EncryptedIdentityError {
     /// Invalid file size
     #[error("Invalid file size: expected {expected} bytes, got {actual}")]
@@ -304,7 +305,8 @@ pub fn load_identity(
 
 /// Save an identity to bytes, optionally encrypting with a password.
 ///
-/// - If `password` is `Some`: encrypt with Argon2id + ChaCha20-Poly1305
+/// - If `password` is `Some(pwd)` where `pwd` is non-empty: encrypt with Argon2id + ChaCha20-Poly1305
+/// - If `password` is `Some(b"")`: return [`EncryptedIdentityError::EmptyPassword`]
 /// - If `password` is `None`: save as plaintext 32-byte key
 pub fn save_identity(
     identity: &Identity,


### PR DESCRIPTION
## Summary

- **Security fix**: `save_identity(identity, Some(b""))` previously fell through to the plaintext code path, silently saving the identity file unencrypted
- Add `EmptyPassword` variant to `EncryptedIdentityError` that is returned when an empty byte slice is provided as the password
- Update existing test to verify the new error behavior instead of asserting plaintext save

Closes #118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty passwords are now rejected with a clear error, preventing accidental plaintext storage and improving security.
* **Tests**
  * Unit tests updated to verify the new empty-password error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->