### PR TITLE
fix: replace mutex panic sites with proper Result propagation

### DIFF
--- a/crates/reme-core/src/lib.rs
+++ b/crates/reme-core/src/lib.rs
@@ -27,6 +27,7 @@ use thiserror::Error;
 use tracing::{debug, info, warn};
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum ClientError {
     #[error("Transport error: {0}")]
     Transport(#[from] TransportError),
@@ -64,7 +65,7 @@ pub enum ClientError {
     #[error("Conflicting duplicate message ID: {0:?}")]
     ConflictingDuplicate(MessageID),
 
-    #[error("Internal lock poisoned")]
+    #[error("Lock poisoned")]
     LockPoisoned,
 }
 

--- a/crates/reme-storage/src/lib.rs
+++ b/crates/reme-storage/src/lib.rs
@@ -49,6 +49,7 @@ pub struct StoredMessage {
 }
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum StorageError {
     #[error("Database error: {0}")]
     Database(#[from] rusqlite::Error),
@@ -68,7 +69,7 @@ pub enum StorageError {
     #[error("Node error: {0}")]
     Node(#[from] NodeError),
 
-    #[error("Internal lock poisoned")]
+    #[error("Lock poisoned")]
     LockPoisoned,
 }
 


### PR DESCRIPTION
## Summary

- Add `StorageError::LockPoisoned` variant and replace all 35 `.expect("mutex poisoned")` calls in `reme-storage` with `.map_err(|_| StorageError::LockPoisoned)?`
- Add `ClientError::LockPoisoned` variant and replace all 5 `dag_state.lock().unwrap()` calls in `reme-core` with `.map_err(|_| ClientError::LockPoisoned)?`
- Change `clear_conversation_dag` and `get_conversation_epoch` return types to `Result` to support the `?` operator

Follows the existing pattern from `reme-node-core/src/mailbox_store.rs` which already uses `NodeError::LockPoisoned`.

Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience by replacing internal panics on synchronization failures with propagated error results.
  * Lock-poisoning scenarios now produce meaningful errors instead of crashing the process.
  * Messaging and storage operations consistently propagate these errors, improving overall stability.
  * Tests updated to handle the new error-returning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->