### PR TITLE
fix: replace MQTT pool panic with error propagation in TUI

### DIFF
--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -1616,7 +1616,7 @@ impl App<'_> {
                 // Add to MQTT pool via registry (which shares the pool with coordinator)
                 self.registry
                     .mqtt_pool()
-                    .expect("MQTT pool always initialized")
+                    .ok_or("MQTT pool not initialized")?
                     .add_target(target);
 
                 // Register in metadata for display


### PR DESCRIPTION
## Summary

- Replace `.expect("MQTT pool always initialized")` with `.ok_or("MQTT pool not initialized")?` in `add_upstream()` — the method already returns `Result<(), String>`, so the error now propagates to the popup UI instead of crashing the TUI
- Addresses **BUG-M3** from the [2026-03-19 code review](spec/analysis/review-2026-03-19.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MQTT upstream addition to gracefully handle unavailable transport pools by returning an error instead of crashing the process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->