### PR TITLE
fix: eliminate TOCTOU race in mDNS stop_advertising

### DIFF
--- a/crates/reme-discovery/src/mdns_sd.rs
+++ b/crates/reme-discovery/src/mdns_sd.rs
@@ -145,7 +145,10 @@ impl DiscoveryBackend for MdnsSdBackend {
         // M1: Hold the lock through the entire operation to avoid TOCTOU.
         // The work below (hostname lookup, ServiceInfo::new, daemon.register)
         // is fast in-process work, not blocking I/O.
-        let mut state = self.state.lock().unwrap();
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| DiscoveryError::LockPoisoned)?;
         if state.advertising {
             return Err(DiscoveryError::AlreadyAdvertising);
         }
@@ -195,7 +198,10 @@ impl DiscoveryBackend for MdnsSdBackend {
         // only to have its `advertising = true` clobbered by a late
         // `advertising = false` write.
         let receiver = {
-            let mut state = self.state.lock().unwrap();
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| DiscoveryError::LockPoisoned)?;
             if !state.advertising {
                 return Err(DiscoveryError::NotAdvertising);
             }
@@ -251,7 +257,10 @@ impl DiscoveryBackend for MdnsSdBackend {
     async fn shutdown(&self) -> Result<(), DiscoveryError> {
         // Take state values under lock.
         let (fullname, browse_handle) = {
-            let mut state = self.state.lock().unwrap();
+            let mut state = self
+                .state
+                .lock()
+                .map_err(|_| DiscoveryError::LockPoisoned)?;
             state.advertising = false;
             state.browsing = false;
             (state.registered_fullname.take(), state.browse_handle.take())

--- a/crates/reme-discovery/src/types.rs
+++ b/crates/reme-discovery/src/types.rs
@@ -79,6 +79,10 @@ pub enum DiscoveryError {
     #[error("not currently advertising")]
     NotAdvertising,
 
+    /// An internal mutex was poisoned (another thread panicked while holding it).
+    #[error("lock poisoned")]
+    LockPoisoned,
+
     /// Catch-all for backend-specific failures.
     #[error("backend error: {0}")]
     BackendError(String),


### PR DESCRIPTION
## Summary

- Fixes a TOCTOU race in `MdnsSdBackend::stop_advertising` where the `advertising` flag and `registered_fullname` were cleared in a second lock acquisition after awaiting unregister confirmation
- Moves state update into the first lock acquisition so state is consistent the moment the lock drops — the unregister await is now purely cleanup
- Eliminates the window where a concurrent `start_advertising` could succeed and then have its state clobbered by the late `advertising = false` write

Closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved mDNS service state handling to make stop/start operations more reliable and reduce lock contention.
* **Bug Fixes**
  * Avoids a race condition where stopping advertising could leave inconsistent state; double-stop now returns the expected "not advertising" response.
* **Tests**
  * Added integration tests covering stop→start cycles and concurrent stop/start stress scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->