### PR TITLE
fix: derive mDNS instance name from routing key, not hostname+PID

### DIFF
--- a/apps/client/src/discovery/mod.rs
+++ b/apps/client/src/discovery/mod.rs
@@ -120,7 +120,7 @@ pub async fn initialize(
         let txt = reme_discovery::encode_txt(&our_rk, port);
         let spec = reme_discovery::AdvertisementSpec {
             txt_records: txt,
-            ..reme_discovery::AdvertisementSpec::new(port)
+            ..reme_discovery::AdvertisementSpec::new(port, our_rk)
         };
 
         if let Err(e) = backend.start_advertising(spec).await {

--- a/crates/reme-discovery/Cargo.toml
+++ b/crates/reme-discovery/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 workspace = true
 
 [features]
-mdns-sd = ["dep:mdns-sd", "dep:hostname"]
+mdns-sd = ["dep:mdns-sd"]
 test-utils = []
 
 [dependencies]
@@ -16,7 +16,6 @@ tokio = { workspace = true, features = ["sync"] }
 thiserror = { workspace = true }
 hex = { workspace = true }
 tracing = { workspace = true }
-hostname = { version = "0.4", optional = true }
 mdns-sd = { version = "0.18", optional = true }
 
 [dev-dependencies]

--- a/crates/reme-discovery/src/fake.rs
+++ b/crates/reme-discovery/src/fake.rs
@@ -146,7 +146,7 @@ mod tests {
     #[tokio::test]
     async fn advertising_state_machine() {
         let backend = FakeDiscoveryBackend::new();
-        let spec = AdvertisementSpec::new(8443);
+        let spec = AdvertisementSpec::new(8443, [0xAA; 16]);
 
         // Cannot stop before starting.
         assert_eq!(
@@ -188,7 +188,7 @@ mod tests {
     #[tokio::test]
     async fn shutdown_stops_advertising() {
         let backend = FakeDiscoveryBackend::new();
-        let spec = AdvertisementSpec::new(8443);
+        let spec = AdvertisementSpec::new(8443, [0xBB; 16]);
 
         backend.start_advertising(spec).await.unwrap();
         backend.shutdown().await.unwrap();

--- a/crates/reme-discovery/src/mdns_sd.rs
+++ b/crates/reme-discovery/src/mdns_sd.rs
@@ -143,8 +143,8 @@ impl MdnsSdBackend {
 impl DiscoveryBackend for MdnsSdBackend {
     async fn start_advertising(&self, spec: AdvertisementSpec) -> Result<(), DiscoveryError> {
         // M1: Hold the lock through the entire operation to avoid TOCTOU.
-        // The work below (hostname lookup, ServiceInfo::new, daemon.register)
-        // is fast in-process work, not blocking I/O.
+        // The work below (ServiceInfo::new, daemon.register) is fast
+        // in-process work, not blocking I/O.
         let mut state = self
             .state
             .lock()
@@ -153,20 +153,15 @@ impl DiscoveryBackend for MdnsSdBackend {
             return Err(DiscoveryError::AlreadyAdvertising);
         }
 
-        let hostname = hostname::get()
-            .ok()
-            .and_then(|h| h.into_string().ok())
-            .unwrap_or_else(|| "reme-node".to_owned());
-
-        let instance_name = format!("{hostname}-{}", std::process::id());
+        let rk_hex = hex::encode(spec.routing_key);
+        let instance_name = format!("reme-{rk_hex}");
+        let host_fqdn = format!("reme-{rk_hex}.local.");
 
         let properties: Vec<(&str, &str)> = spec
             .txt_records
             .iter()
             .map(|(k, v)| (k.as_str(), v.as_str()))
             .collect();
-
-        let host_fqdn = format!("{hostname}.local.");
         let service_info = mdns_sd::ServiceInfo::new(
             &spec.service_type,
             &instance_name,
@@ -347,7 +342,7 @@ mod tests {
             eprintln!("skipping: mDNS daemon unavailable");
             return;
         };
-        let spec = AdvertisementSpec::new(19876);
+        let spec = AdvertisementSpec::new(19876, [0xCC; 16]);
 
         // start → stop → start should succeed without state confusion.
         backend.start_advertising(spec.clone()).await.unwrap();
@@ -377,7 +372,7 @@ mod tests {
         let backend = Arc::new(backend);
 
         for _ in 0..20 {
-            let spec = AdvertisementSpec::new(19877);
+            let spec = AdvertisementSpec::new(19877, [0xDD; 16]);
 
             // Ensure we start from a known state.
             let _ = backend.stop_advertising().await;

--- a/crates/reme-discovery/src/types.rs
+++ b/crates/reme-discovery/src/types.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 use std::net::IpAddr;
 use std::time::Instant;
 
+use crate::txt::RoutingKey;
+
 /// A peer discovered via mDNS/DNS-SD or another discovery backend.
 #[derive(Debug, Clone)]
 pub struct RawDiscoveredPeer {
@@ -41,6 +43,11 @@ pub struct AdvertisementSpec {
     pub port: u16,
     /// TXT record key-value pairs to publish alongside the service.
     pub txt_records: HashMap<String, String>,
+    /// The 16-byte routing key identifying this node.
+    ///
+    /// Used by the mDNS backend to derive a privacy-preserving instance name
+    /// and host FQDN instead of leaking the machine hostname.
+    pub routing_key: RoutingKey,
 }
 
 /// Default service type for reme mDNS advertisements.
@@ -54,12 +61,13 @@ pub const DEFAULT_SERVICE_TYPE: &str = "_reme._tcp.local.";
 pub(crate) const DISCOVERY_CHANNEL_CAPACITY: usize = 128;
 
 impl AdvertisementSpec {
-    /// Create a new advertisement spec with the given port and default service type.
-    pub fn new(port: u16) -> Self {
+    /// Create a new advertisement spec with the given port, routing key, and default service type.
+    pub fn new(port: u16, routing_key: RoutingKey) -> Self {
         Self {
             service_type: DEFAULT_SERVICE_TYPE.to_owned(),
             port,
             txt_records: HashMap::new(),
+            routing_key,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replace `{hostname}-{pid}` with `reme-{hex(routing_key)}` for mDNS instance name and host FQDN
- Add required `routing_key: RoutingKey` field to `AdvertisementSpec`
- Remove `hostname` crate dependency from `reme-discovery`

The routing key is already broadcast in TXT records, so this leaks no additional information while eliminating hostname and PID exposure on the LAN.

**New follow-up issue:** #146 tracks cross-session linkability from the stable routing-key-derived name (low priority — routing key already public in TXT).

Fixes #108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced service discovery with deterministic identifier-based naming to ensure consistent and stable service instance identification across different system environments.

* **Chores**
  * Optimized dependency management by removing unnecessary optional dependencies, resulting in a cleaner and more maintainable package structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->