### PR TITLE
ci: add CodeQL code scanning for Rust

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,4 +1,4 @@
-name: CodeQL
+name: codeql.yml
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
     - cron: "23 4 * * 1"
 
 permissions:
+  actions: read
   contents: read
   security-events: write
 
@@ -23,7 +24,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

- Add CodeQL analysis workflow for Rust using `build-mode: none` (no compilation required, GA since Oct 2025)
- Runs on push/PR to main/master + weekly scheduled scan
- All actions pinned to commit SHAs with `persist-credentials: false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated CodeQL security analysis to run on commits, pull requests, and a weekly schedule, improving vulnerability detection and reporting.
  * Configured the analysis to include Rust projects and to run with safe defaults to limit impact on routine CI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->