### PR TITLE
docs: comprehensive LAN discovery documentation

### DIFF
--- a/docs/lan-discovery.md
+++ b/docs/lan-discovery.md
@@ -174,7 +174,7 @@ The stranger cache solves this: when a discovered peer's routing key doesn't mat
 cache is scanned for matching routing keys. Matches are removed from the cache and fed through the standard identity
 verification flow.
 
-- **Size cap:** bounded by `max_peers` (default 256)
+- **Size cap:** bounded independently by `max_peers` (default 256), separate from the verified peer cap
 - **Updates:** already-cached strangers are updated on `PeerUpdated` even when the cache is full
 - **Cleanup:** entries are removed on `PeerLost` events and on controller shutdown
 - **Failed re-processing:** strangers that fail verification after contact-add are silently dropped (not re-cached);
@@ -207,7 +207,8 @@ enabled = true
 # no peer verification, no target registration.
 auto_direct_known_contacts = true
 
-# Maximum number of tracked peers (verified + stranger cache).
+# Maximum tracked entries per index (verified peers and stranger cache
+# are capped independently, so total tracked entries can reach ~2x this value).
 # Default: 256
 max_peers = 256
 
@@ -278,7 +279,7 @@ For the full threat analysis, see [threat-model.md](threat-model.md).
 
 ```
 crates/reme-discovery/
-├── backend.rs       # DiscoveryBackend trait (start_advertising, subscribe, shutdown)
+├── backend.rs       # DiscoveryBackend trait (start_advertising, stop_advertising, subscribe, shutdown)
 ├── types.rs         # RawDiscoveredPeer, DiscoveryEvent, AdvertisementSpec
 ├── txt.rs           # TXT record encode/decode (v, rk, port)
 ├── mdns_sd.rs       # MdnsSdBackend — production implementation using mdns-sd crate

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -40,7 +40,7 @@ Attack scenarios, mitigations, and residual risks for the reme messaging system.
 **Attack**: Mallory floods the network with thousands of mDNS advertisements, each with a different routing key, attempting to exhaust the discovery controller's resources.
 
 **Mitigation**:
-- The controller enforces a hard cap of 256 tracked peers (verified + stranger cache, both bounded by `max_peers`)
+- The controller enforces `max_peers` (default 256) independently on verified peers and the stranger cache, bounding total tracked entries at ~2x `max_peers`
 - Only peers whose routing key matches a known contact are verified and registered; strangers are cached (not verified) for later matching when new contacts are added
 - Identity verification is concurrent (JoinSet) with 2s connect / 5s total HTTP timeouts, bounding total refresh time
 - The mDNS-SD backend uses `broadcast` channels that drop events on lag rather than growing unboundedly


### PR DESCRIPTION
## Summary

- Add `docs/lan-discovery.md` — comprehensive documentation of the LAN discovery mechanism with Mermaid diagrams
- Covers operating modes (full vs advertise-only), mDNS format, identity verification protocol, stranger cache, concurrent refresh, configuration, and security analysis
- Update `docs/threat-model.md` to reflect stranger cache and concurrent refresh behavior

Documents the `auto_direct_known_contacts = false` advertise-only behavior.

Closes #107.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docs for automatic LAN peer discovery and local P2P messaging, covering advertisement vs. browse modes, identity verification flow, ephemeral peer registration, stranger-cache semantics, periodic refresh and failure handling.
  * Updated the threat model to clarify per-category peer limits, stranger-cache effects, concurrent verification timing and timeouts, and residual attack vectors and mitigations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->