### PR TITLE
feat(tui): slash command framework + cosmetic commands

### DIFF
--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -426,6 +426,8 @@ pub struct App<'a> {
     action_rx: mpsc::UnboundedReceiver<Action>,
     /// Monotonic counter for correlating send results to optimistic messages.
     next_send_id: u64,
+    /// Slash command completion popup state.
+    pub command_completion: super::commands::CommandCompletionState,
 }
 
 impl App<'_> {
@@ -612,6 +614,9 @@ impl App<'_> {
             action_tx,
             action_rx,
             next_send_id: 0,
+            command_completion: super::commands::CommandCompletionState::new(
+                super::commands::Registry::builtin(),
+            ),
         };
 
         // Surface mDNS init failure in TUI status bar (M14)
@@ -1132,6 +1137,37 @@ impl App<'_> {
             _ => {}
         }
 
+        // Slash command completion popup — intercepts keys before the
+        // global Esc/Tab focus-switch block below. Only active when
+        // input is focused and the user is currently typing a command.
+        if self.focus == Focus::Input && self.command_completion.is_active() {
+            use super::commands::CompletionOutcome;
+            match self.command_completion.handle_key(key) {
+                CompletionOutcome::Consumed => {
+                    if key.code == KeyCode::Tab {
+                        if let Some(insertion) = self.command_completion.tab_insertion() {
+                            let mut new_input = TextArea::default();
+                            new_input.set_placeholder_text("Type a message...");
+                            new_input.insert_str(&insertion);
+                            self.input = new_input;
+                            let line = self.input.lines()[0].clone();
+                            self.command_completion.update_from_input(&line);
+                        }
+                    }
+                    return Ok(());
+                }
+                CompletionOutcome::Exit => {
+                    self.command_completion.suppress();
+                    return Ok(());
+                }
+                CompletionOutcome::Dispatch(parsed) => {
+                    self.dispatch_command(&parsed);
+                    return Ok(());
+                }
+                CompletionOutcome::PassThrough => {}
+            }
+        }
+
         #[allow(clippy::wildcard_enum_match_arm)] // KeyCode has 27+ variants
         match key.code {
             KeyCode::Esc => {
@@ -1227,7 +1263,22 @@ impl App<'_> {
     #[allow(clippy::unnecessary_wraps)] // Returns Result for consistency with other handlers
     fn handle_input_key(&mut self, key: KeyEvent) -> AppResult<()> {
         if key.code == KeyCode::Enter {
-            let text = self.input.lines().join("\n");
+            let raw = self.input.lines().join("\n");
+
+            // Command-mode Enter dispatch for the popup-inactive case
+            // (e.g. user pressed Esc after typing, then pressed Enter).
+            if super::commands::is_command_mode(&raw) {
+                if let Ok(parsed) = super::commands::parse(&raw) {
+                    self.dispatch_command(&parsed);
+                } else {
+                    self.status = "Invalid command".to_string();
+                }
+                return Ok(());
+            }
+
+            // Escape sequence: '//foo' sends literal '/foo'.
+            let text = super::commands::strip_escape(&raw).to_string();
+
             if !text.trim().is_empty() {
                 if let Some(conv) = self.conversation_list.selected() {
                     let public_id = conv.public_id;
@@ -1253,7 +1304,6 @@ impl App<'_> {
                             self.input.set_placeholder_text("Type a message...");
                             self.status = "Sending...".to_string();
 
-                            // Update conversation preview and timestamp
                             if let Some(sel) = self.conversation_list.selected_mut() {
                                 sel.last_message = Some(text);
                                 sel.last_message_time = Some(now_secs());
@@ -1280,8 +1330,80 @@ impl App<'_> {
         } else {
             let input = Input::from(key);
             self.input.input(input);
+
+            let line = self.input.lines().first().cloned().unwrap_or_default();
+            self.command_completion.update_from_input(&line);
         }
         Ok(())
+    }
+
+    /// Dispatch a parsed slash command. Resolves the command name against a
+    /// fresh registry and executes it. `/help <name>` is special-cased here
+    /// because `Help::execute` can't see the registry at the trait level.
+    fn dispatch_command(&mut self, parsed: &super::commands::ParsedCommand<'_>) {
+        use super::commands::{CommandAction, CommandContext, Registry};
+
+        let registry = Registry::builtin();
+
+        if parsed.name == "help" && !parsed.args.is_empty() {
+            let target = parsed.args.split_whitespace().next().unwrap_or("");
+            let status = match registry.find(target) {
+                Some(cmd) => format!("{} — {}", cmd.usage(), cmd.help()),
+                None => format!("Unknown command: /{target}"),
+            };
+            self.apply_command_action(CommandAction::Status(status));
+            return;
+        }
+
+        let Some(cmd) = registry.find(parsed.name) else {
+            self.status = format!("Unknown command: /{}", parsed.name);
+            return;
+        };
+        let ctx = CommandContext::new();
+        let actions = cmd.execute(&ctx, parsed.args);
+        for action in actions {
+            self.apply_command_action(action);
+        }
+    }
+
+    /// Apply a single `CommandAction` to the app state.
+    fn apply_command_action(&mut self, action: super::commands::CommandAction) {
+        use super::commands::CommandAction;
+
+        match action {
+            CommandAction::ReplaceInput(text) => {
+                let mut new_input = TextArea::default();
+                new_input.set_placeholder_text("Type a message...");
+                new_input.insert_str(&text);
+                self.input = new_input;
+                self.command_completion.reset();
+            }
+            CommandAction::ClearScrollback => {
+                self.messages.clear();
+                self.message_scroll = 0;
+                if let Some(conv) = self.conversation_list.selected() {
+                    let public_id = conv.public_id;
+                    if let Some(cache) = self.message_cache.get_mut(&public_id) {
+                        cache.clear();
+                    }
+                }
+                self.command_completion.reset();
+                let mut new_input = TextArea::default();
+                new_input.set_placeholder_text("Type a message...");
+                self.input = new_input;
+            }
+            CommandAction::Quit => {
+                self.running = false;
+                self.command_completion.reset();
+            }
+            CommandAction::Status(msg) => {
+                self.status = msg;
+                self.command_completion.reset();
+                let mut new_input = TextArea::default();
+                new_input.set_placeholder_text("Type a message...");
+                self.input = new_input;
+            }
+        }
     }
 
     /// Cache a message with size limit (O(1) eviction using `VecDeque`)

--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -1145,6 +1145,9 @@ impl App<'_> {
                 CompletionOutcome::Consumed => {
                     if key.code == KeyCode::Tab {
                         if let Some(insertion) = self.command_completion.tab_insertion() {
+                            // TODO(#232): modify self.input in place (preserves undo
+                            // history) and splice the arg portion when arg completion
+                            // lands, instead of replacing the whole textarea.
                             let mut input = Self::fresh_input();
                             input.insert_str(&insertion);
                             self.input = input;
@@ -1344,10 +1347,17 @@ impl App<'_> {
     fn dispatch_command(&mut self, parsed: &super::commands::ParsedCommandOwned) {
         use super::commands::{CommandAction, CommandContext, Registry};
 
+        // TODO(#232): reuse registry from self.command_completion via a getter
+        // instead of allocating a fresh one. Blocked on borrow-checker work
+        // (apply_command_action needs &mut self while registry is borrowed).
         let registry = Registry::builtin();
 
+        // TODO(#232): move this into Help::execute when CommandContext gains
+        // a registry reference — eliminates both the special case here and
+        // the hardcoded list in builtin::Help.
         if parsed.name == "help" && !parsed.args.is_empty() {
-            let target = parsed.args.split_whitespace().next().unwrap_or("");
+            let raw_target = parsed.args.split_whitespace().next().unwrap_or("");
+            let target = raw_target.strip_prefix('/').unwrap_or(raw_target);
             let status = match registry.find(target) {
                 Some(cmd) => format!("{} — {}", cmd.usage(), cmd.help()),
                 None => format!("Unknown command: /{target}"),

--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -426,8 +426,7 @@ pub struct App<'a> {
     action_rx: mpsc::UnboundedReceiver<Action>,
     /// Monotonic counter for correlating send results to optimistic messages.
     next_send_id: u64,
-    /// Slash command completion popup state.
-    pub command_completion: super::commands::CommandCompletionState,
+    pub(crate) command_completion: super::commands::CommandCompletionState,
 }
 
 impl App<'_> {
@@ -1146,10 +1145,9 @@ impl App<'_> {
                 CompletionOutcome::Consumed => {
                     if key.code == KeyCode::Tab {
                         if let Some(insertion) = self.command_completion.tab_insertion() {
-                            let mut new_input = TextArea::default();
-                            new_input.set_placeholder_text("Type a message...");
-                            new_input.insert_str(&insertion);
-                            self.input = new_input;
+                            let mut input = Self::fresh_input();
+                            input.insert_str(&insertion);
+                            self.input = input;
                             let line = self.input.lines()[0].clone();
                             self.command_completion.update_from_input(&line);
                         }
@@ -1269,7 +1267,7 @@ impl App<'_> {
             // (e.g. user pressed Esc after typing, then pressed Enter).
             if super::commands::is_command_mode(&raw) {
                 if let Ok(parsed) = super::commands::parse(&raw) {
-                    self.dispatch_command(&parsed);
+                    self.dispatch_command(&parsed.into_owned());
                 } else {
                     self.status = "Invalid command".to_string();
                 }
@@ -1300,8 +1298,7 @@ impl App<'_> {
 
                             self.cache_message(public_id, message.clone());
                             self.messages.push(message);
-                            self.input = TextArea::default();
-                            self.input.set_placeholder_text("Type a message...");
+                            self.input = Self::fresh_input();
                             self.status = "Sending...".to_string();
 
                             if let Some(sel) = self.conversation_list.selected_mut() {
@@ -1337,10 +1334,14 @@ impl App<'_> {
         Ok(())
     }
 
-    /// Dispatch a parsed slash command. Resolves the command name against a
-    /// fresh registry and executes it. `/help <name>` is special-cased here
-    /// because `Help::execute` can't see the registry at the trait level.
-    fn dispatch_command(&mut self, parsed: &super::commands::ParsedCommand<'_>) {
+    fn fresh_input() -> TextArea<'static> {
+        let mut input = TextArea::default();
+        input.set_placeholder_text("Type a message...");
+        input.set_cursor_line_style(Style::default());
+        input
+    }
+
+    fn dispatch_command(&mut self, parsed: &super::commands::ParsedCommandOwned) {
         use super::commands::{CommandAction, CommandContext, Registry};
 
         let registry = Registry::builtin();
@@ -1355,12 +1356,12 @@ impl App<'_> {
             return;
         }
 
-        let Some(cmd) = registry.find(parsed.name) else {
+        let Some(cmd) = registry.find(&parsed.name) else {
             self.status = format!("Unknown command: /{}", parsed.name);
             return;
         };
         let ctx = CommandContext::new();
-        let actions = cmd.execute(&ctx, parsed.args);
+        let actions = cmd.execute(&ctx, &parsed.args);
         for action in actions {
             self.apply_command_action(action);
         }
@@ -1372,10 +1373,9 @@ impl App<'_> {
 
         match action {
             CommandAction::ReplaceInput(text) => {
-                let mut new_input = TextArea::default();
-                new_input.set_placeholder_text("Type a message...");
-                new_input.insert_str(&text);
-                self.input = new_input;
+                let mut input = Self::fresh_input();
+                input.insert_str(&text);
+                self.input = input;
                 self.command_completion.reset();
             }
             CommandAction::ClearScrollback => {
@@ -1388,9 +1388,7 @@ impl App<'_> {
                     }
                 }
                 self.command_completion.reset();
-                let mut new_input = TextArea::default();
-                new_input.set_placeholder_text("Type a message...");
-                self.input = new_input;
+                self.input = Self::fresh_input();
             }
             CommandAction::Quit => {
                 self.running = false;
@@ -1399,9 +1397,7 @@ impl App<'_> {
             CommandAction::Status(msg) => {
                 self.status = msg;
                 self.command_completion.reset();
-                let mut new_input = TextArea::default();
-                new_input.set_placeholder_text("Type a message...");
-                self.input = new_input;
+                self.input = Self::fresh_input();
             }
         }
     }

--- a/apps/client/src/tui/app.rs
+++ b/apps/client/src/tui/app.rs
@@ -1328,8 +1328,8 @@ impl App<'_> {
             let input = Input::from(key);
             self.input.input(input);
 
-            let line = self.input.lines().first().cloned().unwrap_or_default();
-            self.command_completion.update_from_input(&line);
+            let text = self.input.lines().join("\n");
+            self.command_completion.update_from_input(&text);
         }
         Ok(())
     }

--- a/apps/client/src/tui/commands/builtin.rs
+++ b/apps/client/src/tui/commands/builtin.rs
@@ -1,0 +1,255 @@
+//! Built-in slash command implementations for v1.
+//!
+//! All six commands are client-local: no wire traffic, no `BackendHandle`.
+//! Each `execute` is pure — takes a `CommandContext` and args, returns
+//! a list of `CommandAction`s for `App` to apply.
+
+use super::{Command, CommandAction, CommandContext, CompletionEntry};
+
+// ── /tableflip ──────────────────────────────────────────────────────
+
+pub struct TableFlip;
+
+impl Command for TableFlip {
+    fn name(&self) -> &'static str {
+        "tableflip"
+    }
+    fn help(&self) -> &'static str {
+        "Flip the table"
+    }
+    fn usage(&self) -> &'static str {
+        "/tableflip [text]"
+    }
+    fn execute(&self, _ctx: &CommandContext<'_>, args: &str) -> Vec<CommandAction> {
+        let body = if args.is_empty() {
+            "(╯°□°)╯︵ ┻━┻".to_string()
+        } else {
+            format!("{args} (╯°□°)╯︵ ┻━┻")
+        };
+        vec![CommandAction::ReplaceInput(body)]
+    }
+}
+
+// ── /shrug ──────────────────────────────────────────────────────────
+
+pub struct Shrug;
+
+impl Command for Shrug {
+    fn name(&self) -> &'static str {
+        "shrug"
+    }
+    fn aliases(&self) -> &'static [&'static str] {
+        &["sh"]
+    }
+    fn help(&self) -> &'static str {
+        r"¯\_(ツ)_/¯"
+    }
+    fn usage(&self) -> &'static str {
+        "/shrug [text]"
+    }
+    fn execute(&self, _ctx: &CommandContext<'_>, args: &str) -> Vec<CommandAction> {
+        let body = if args.is_empty() {
+            r"¯\_(ツ)_/¯".to_string()
+        } else {
+            format!(r"{args} ¯\_(ツ)_/¯")
+        };
+        vec![CommandAction::ReplaceInput(body)]
+    }
+}
+
+// ── /me ─────────────────────────────────────────────────────────────
+
+pub struct Me;
+
+impl Command for Me {
+    fn name(&self) -> &'static str {
+        "me"
+    }
+    fn help(&self) -> &'static str {
+        "IRC-style action message"
+    }
+    fn usage(&self) -> &'static str {
+        "/me <action>"
+    }
+    fn execute(&self, _ctx: &CommandContext<'_>, args: &str) -> Vec<CommandAction> {
+        if args.is_empty() {
+            vec![CommandAction::Status("usage: /me <action>".to_string())]
+        } else {
+            vec![CommandAction::ReplaceInput(format!("* {args}"))]
+        }
+    }
+}
+
+// ── /clear ──────────────────────────────────────────────────────────
+
+pub struct Clear;
+
+impl Command for Clear {
+    fn name(&self) -> &'static str {
+        "clear"
+    }
+    fn help(&self) -> &'static str {
+        "Clear visible scrollback (does not touch storage)"
+    }
+    fn usage(&self) -> &'static str {
+        "/clear"
+    }
+    fn execute(&self, _ctx: &CommandContext<'_>, _args: &str) -> Vec<CommandAction> {
+        vec![CommandAction::ClearScrollback]
+    }
+}
+
+// ── /quit ───────────────────────────────────────────────────────────
+
+pub struct Quit;
+
+impl Command for Quit {
+    fn name(&self) -> &'static str {
+        "quit"
+    }
+    fn help(&self) -> &'static str {
+        "Exit the client"
+    }
+    fn usage(&self) -> &'static str {
+        "/quit"
+    }
+    fn execute(&self, _ctx: &CommandContext<'_>, _args: &str) -> Vec<CommandAction> {
+        vec![CommandAction::Quit]
+    }
+}
+
+// ── /help ───────────────────────────────────────────────────────────
+
+pub struct Help;
+
+impl Command for Help {
+    fn name(&self) -> &'static str {
+        "help"
+    }
+    fn help(&self) -> &'static str {
+        "Show command help"
+    }
+    fn usage(&self) -> &'static str {
+        "/help [command]"
+    }
+    fn execute(&self, _ctx: &CommandContext<'_>, _args: &str) -> Vec<CommandAction> {
+        // Always list-only. The `/help <name>` case is intercepted in
+        // `App::dispatch_command` (see Task 16) because `execute` can't
+        // see the registry to resolve target-command usage + help.
+        vec![CommandAction::Status(
+            "/help /tableflip /shrug /me /clear /quit".to_string(),
+        )]
+    }
+
+    fn complete_args(&self, _args_so_far: &str) -> Vec<CompletionEntry> {
+        // Could complete to other command names, but v1 doesn't invest
+        // in nested completion. Status one-liner is enough.
+        Vec::new()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> CommandContext<'static> {
+        CommandContext::new()
+    }
+
+    #[test]
+    fn tableflip_no_args() {
+        let actions = TableFlip.execute(&ctx(), "");
+        assert_eq!(
+            actions,
+            vec![CommandAction::ReplaceInput("(╯°□°)╯︵ ┻━┻".to_string())]
+        );
+    }
+
+    #[test]
+    fn tableflip_with_args() {
+        let actions = TableFlip.execute(&ctx(), "hello world");
+        assert_eq!(
+            actions,
+            vec![CommandAction::ReplaceInput(
+                "hello world (╯°□°)╯︵ ┻━┻".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn shrug_no_args() {
+        let actions = Shrug.execute(&ctx(), "");
+        assert_eq!(
+            actions,
+            vec![CommandAction::ReplaceInput(r"¯\_(ツ)_/¯".to_string())]
+        );
+    }
+
+    #[test]
+    fn shrug_with_args() {
+        let actions = Shrug.execute(&ctx(), "whatever");
+        assert_eq!(
+            actions,
+            vec![CommandAction::ReplaceInput(
+                r"whatever ¯\_(ツ)_/¯".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn shrug_has_sh_alias() {
+        assert_eq!(Shrug.aliases(), &["sh"]);
+    }
+
+    #[test]
+    fn me_with_args() {
+        let actions = Me.execute(&ctx(), "waves at bob");
+        assert_eq!(
+            actions,
+            vec![CommandAction::ReplaceInput("* waves at bob".to_string())]
+        );
+    }
+
+    #[test]
+    fn me_without_args_returns_usage_status() {
+        let actions = Me.execute(&ctx(), "");
+        assert_eq!(
+            actions,
+            vec![CommandAction::Status("usage: /me <action>".to_string())]
+        );
+    }
+
+    #[test]
+    fn clear_returns_clear_scrollback() {
+        let actions = Clear.execute(&ctx(), "");
+        assert_eq!(actions, vec![CommandAction::ClearScrollback]);
+    }
+
+    #[test]
+    fn clear_ignores_args() {
+        let actions = Clear.execute(&ctx(), "anything");
+        assert_eq!(actions, vec![CommandAction::ClearScrollback]);
+    }
+
+    #[test]
+    fn quit_returns_quit_action() {
+        let actions = Quit.execute(&ctx(), "");
+        assert_eq!(actions, vec![CommandAction::Quit]);
+    }
+
+    #[test]
+    fn help_lists_all_commands_in_status() {
+        let actions = Help.execute(&ctx(), "");
+        let status = match actions.as_slice() {
+            [CommandAction::Status(s)] => s.clone(),
+            _ => panic!("expected Status action"),
+        };
+        assert!(status.contains("/help"));
+        assert!(status.contains("/tableflip"));
+        assert!(status.contains("/shrug"));
+        assert!(status.contains("/me"));
+        assert!(status.contains("/clear"));
+        assert!(status.contains("/quit"));
+    }
+}

--- a/apps/client/src/tui/commands/builtin.rs
+++ b/apps/client/src/tui/commands/builtin.rs
@@ -133,9 +133,8 @@ impl Command for Help {
         "/help [command]"
     }
     fn execute(&self, _ctx: &CommandContext<'_>, _args: &str) -> Vec<CommandAction> {
-        // Always list-only. The `/help <name>` case is intercepted in
-        // `App::dispatch_command` (see Task 16) because `execute` can't
-        // see the registry to resolve target-command usage + help.
+        // TODO(#232): generate dynamically from the registry when
+        // CommandContext gains a registry reference.
         vec![CommandAction::Status(
             "/help /tableflip /shrug /me /clear /quit".to_string(),
         )]

--- a/apps/client/src/tui/commands/complete.rs
+++ b/apps/client/src/tui/commands/complete.rs
@@ -2,15 +2,18 @@
 
 use super::{Command, CompletionEntry};
 
-/// Return all registered commands whose name starts with `prefix`,
-/// sorted alphabetically by display label. A leading `/` on the
-/// prefix is tolerated and stripped.
+/// Return all registered commands whose name or aliases start with `prefix`,
+/// sorted alphabetically by display label. A leading `/` on the prefix is
+/// tolerated and stripped. Deduplicates: if a command matches on both name
+/// and alias, it appears once (by canonical name).
 pub(super) fn complete_name(commands: &[Box<dyn Command>], prefix: &str) -> Vec<CompletionEntry> {
     let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
 
     let mut entries: Vec<CompletionEntry> = commands
         .iter()
-        .filter(|cmd| cmd.name().starts_with(prefix))
+        .filter(|cmd| {
+            cmd.name().starts_with(prefix) || cmd.aliases().iter().any(|a| a.starts_with(prefix))
+        })
         .map(|cmd| CompletionEntry {
             insert: format!("/{}", cmd.name()),
             label: format!("/{}", cmd.name()),

--- a/apps/client/src/tui/commands/complete.rs
+++ b/apps/client/src/tui/commands/complete.rs
@@ -1,0 +1,23 @@
+//! Completion engine: name-prefix matching and per-command arg completion.
+
+use super::{Command, CompletionEntry};
+
+/// Return all registered commands whose name starts with `prefix`,
+/// sorted alphabetically by display label. A leading `/` on the
+/// prefix is tolerated and stripped.
+pub(super) fn complete_name(commands: &[Box<dyn Command>], prefix: &str) -> Vec<CompletionEntry> {
+    let prefix = prefix.strip_prefix('/').unwrap_or(prefix);
+
+    let mut entries: Vec<CompletionEntry> = commands
+        .iter()
+        .filter(|cmd| cmd.name().starts_with(prefix))
+        .map(|cmd| CompletionEntry {
+            insert: format!("/{}", cmd.name()),
+            label: format!("/{}", cmd.name()),
+            help: cmd.help().to_string(),
+        })
+        .collect();
+
+    entries.sort_by(|a, b| a.label.cmp(&b.label));
+    entries
+}

--- a/apps/client/src/tui/commands/mod.rs
+++ b/apps/client/src/tui/commands/mod.rs
@@ -1,0 +1,211 @@
+//! Chat slash commands: framework + cosmetic commands.
+//!
+//! See `spec/plans/2026-04-16-slash-commands-design.md` for the full design
+//! and `spec/plans/2026-04-16-slash-commands-v1-plan.md` for the
+//! implementation plan. Tracking: #234 (parent), #231 (this work).
+//!
+//! # Layout
+//!
+//! - [`parser`] — single-responsibility string parsing
+//! - [`complete`] — name-prefix completion + per-command arg completion hook
+//! - [`builtin`] — six v1 commands: `/help /tableflip /shrug /me /clear /quit`
+//! - [`popup`] — `CommandCompletionState`: popup + ghost text state machine
+
+pub mod builtin;
+pub mod complete;
+pub mod parser;
+pub mod popup;
+
+pub use parser::{is_command_mode, parse, strip_escape, ParsedCommand};
+pub use popup::{CommandCompletionState, CompletionOutcome};
+
+/// A single slash command, e.g. `/tableflip`.
+pub trait Command: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn aliases(&self) -> &'static [&'static str] {
+        &[]
+    }
+    fn help(&self) -> &'static str;
+    fn usage(&self) -> &'static str;
+    fn execute(&self, ctx: &CommandContext<'_>, args: &str) -> Vec<CommandAction>;
+
+    /// Candidates for the next argument, given what's typed so far.
+    /// Default: no arg completion. Commands that want argument completion
+    /// (e.g. a future `/p2p tor|iroh|<ip>`) override this.
+    fn complete_args(&self, _args_so_far: &str) -> Vec<CompletionEntry> {
+        Vec::new()
+    }
+}
+
+/// Context passed to `Command::execute`. Empty in v1; grows in follow-up PRs
+/// to carry selected-contact info and a `BackendHandle` reference (#232).
+#[derive(Debug, Default)]
+pub struct CommandContext<'a> {
+    _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> CommandContext<'a> {
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            _lifetime: std::marker::PhantomData,
+        }
+    }
+}
+
+/// Side effects a command can request. `App::apply_command_action` is the
+/// interpreter.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CommandAction {
+    /// Replace the textarea contents with the given string. Does not send.
+    ReplaceInput(String),
+    /// Clear the visible scrollback (and the cache entry for the selected
+    /// contact). Does NOT touch persistent storage or bump the epoch.
+    ClearScrollback,
+    /// Exit the client, same as Ctrl+Q.
+    Quit,
+    /// Write a one-line message to the status bar.
+    Status(String),
+    // Future variants reserved for follow-up PRs:
+    //   SendText(String),
+    //   BackendCall(BackendRequest),
+    //   StartEphemeralSession(TransportKind),
+    //   ShowPopup(PopupKind),
+}
+
+/// One entry in the completion popup. `insert` is what Tab writes into the
+/// textarea; `label` is what the popup displays (usually the same);
+/// `help` is the dimmed help column on the right.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompletionEntry {
+    pub insert: String,
+    pub label: String,
+    pub help: String,
+}
+
+/// Registry of all known commands. Cheap to construct — six `Box<dyn Command>`
+/// allocations — so callers that need a temporary (e.g. `App::dispatch_command`)
+/// can build a fresh one instead of threading a borrow.
+pub struct Registry {
+    commands: Vec<Box<dyn Command>>,
+}
+
+impl Registry {
+    #[must_use]
+    pub fn builtin() -> Self {
+        Self {
+            commands: vec![
+                Box::new(builtin::Help),
+                Box::new(builtin::TableFlip),
+                Box::new(builtin::Shrug),
+                Box::new(builtin::Me),
+                Box::new(builtin::Clear),
+                Box::new(builtin::Quit),
+            ],
+        }
+    }
+
+    /// Find a command by name or alias. A leading `/` is tolerated.
+    #[must_use]
+    pub fn find(&self, name: &str) -> Option<&dyn Command> {
+        let name = name.strip_prefix('/').unwrap_or(name);
+        self.commands.iter().find_map(|cmd| {
+            if cmd.name() == name || cmd.aliases().contains(&name) {
+                Some(cmd.as_ref())
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Return candidates whose name starts with `prefix`, sorted alphabetically.
+    /// An empty prefix returns all commands. A leading `/` on the prefix is
+    /// tolerated.
+    #[must_use]
+    pub fn complete(&self, prefix: &str) -> Vec<CompletionEntry> {
+        complete::complete_name(&self.commands, prefix)
+    }
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self::builtin()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builtin_registry_has_all_six_commands() {
+        let r = Registry::builtin();
+        assert!(r.find("help").is_some());
+        assert!(r.find("tableflip").is_some());
+        assert!(r.find("shrug").is_some());
+        assert!(r.find("me").is_some());
+        assert!(r.find("clear").is_some());
+        assert!(r.find("quit").is_some());
+    }
+
+    #[test]
+    fn builtin_registry_unknown_is_none() {
+        let r = Registry::builtin();
+        assert!(r.find("nonsense").is_none());
+    }
+
+    #[test]
+    fn builtin_registry_strips_leading_slash() {
+        let r = Registry::builtin();
+        assert!(r.find("/tableflip").is_some());
+    }
+
+    #[test]
+    fn builtin_registry_resolves_shrug_alias() {
+        let r = Registry::builtin();
+        assert_eq!(r.find("sh").unwrap().name(), "shrug");
+    }
+
+    #[test]
+    fn complete_empty_prefix_returns_all_sorted() {
+        let r = Registry::builtin();
+        let entries = r.complete("");
+        assert_eq!(entries.len(), 6);
+        let names: Vec<&str> = entries.iter().map(|e| e.label.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["/clear", "/help", "/me", "/quit", "/shrug", "/tableflip"]
+        );
+    }
+
+    #[test]
+    fn complete_prefix_filters() {
+        let r = Registry::builtin();
+        let entries = r.complete("ta");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].label, "/tableflip");
+        assert_eq!(entries[0].insert, "/tableflip");
+    }
+
+    #[test]
+    fn complete_prefix_with_leading_slash_works() {
+        let r = Registry::builtin();
+        let entries = r.complete("/sh");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].label, "/shrug");
+    }
+
+    #[test]
+    fn complete_unknown_prefix_returns_empty() {
+        let r = Registry::builtin();
+        assert!(r.complete("xyz").is_empty());
+    }
+
+    #[test]
+    fn complete_includes_help_column_from_command() {
+        let r = Registry::builtin();
+        let entries = r.complete("ta");
+        assert_eq!(entries[0].help, "Flip the table");
+    }
+}

--- a/apps/client/src/tui/commands/mod.rs
+++ b/apps/client/src/tui/commands/mod.rs
@@ -1,22 +1,11 @@
 //! Chat slash commands: framework + cosmetic commands.
-//!
-//! See `spec/plans/2026-04-16-slash-commands-design.md` for the full design
-//! and `spec/plans/2026-04-16-slash-commands-v1-plan.md` for the
-//! implementation plan. Tracking: #234 (parent), #231 (this work).
-//!
-//! # Layout
-//!
-//! - [`parser`] — single-responsibility string parsing
-//! - [`complete`] — name-prefix completion + per-command arg completion hook
-//! - [`builtin`] — six v1 commands: `/help /tableflip /shrug /me /clear /quit`
-//! - [`popup`] — `CommandCompletionState`: popup + ghost text state machine
 
 pub mod builtin;
 pub mod complete;
 pub mod parser;
 pub mod popup;
 
-pub use parser::{is_command_mode, parse, strip_escape, ParsedCommand};
+pub use parser::{is_command_mode, parse, strip_escape, ParsedCommandOwned};
 pub use popup::{CommandCompletionState, CompletionOutcome};
 
 /// A single slash command, e.g. `/tableflip`.

--- a/apps/client/src/tui/commands/parser.rs
+++ b/apps/client/src/tui/commands/parser.rs
@@ -1,0 +1,223 @@
+//! Slash command parser.
+
+use thiserror::Error;
+
+/// Parsed form of a slash command input string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedCommand<'a> {
+    /// Command name without the leading `/`.
+    pub name: &'a str,
+    /// Everything after the first whitespace. Commands parse their own args.
+    pub args: &'a str,
+}
+
+impl ParsedCommand<'_> {
+    /// Convert to a `'static` lifetime by leaking owned strings.
+    ///
+    /// Used by `CompletionOutcome::Dispatch` so the outcome can be passed
+    /// back through `App` without borrowing from the textarea state.
+    /// Leak is bounded: one dispatch per user Enter press, small strings.
+    /// If this ever becomes a memory concern, replace with a
+    /// `ParsedCommandOwned { name: String, args: String }` struct.
+    #[must_use]
+    pub fn into_owned(self) -> ParsedCommand<'static> {
+        let name = Box::leak(self.name.to_string().into_boxed_str());
+        let args = Box::leak(self.args.to_string().into_boxed_str());
+        ParsedCommand { name, args }
+    }
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum ParseError {
+    #[error("empty command")]
+    Empty,
+    #[error("invalid command syntax")]
+    Invalid,
+}
+
+/// Parse a slash command input into `(name, args)`.
+///
+/// Rejects: empty/whitespace-only text, missing leading `/`, leading
+/// whitespace before the `/`, and names that don't start with an ASCII
+/// alphanumeric byte.
+pub fn parse(text: &str) -> Result<ParsedCommand<'_>, ParseError> {
+    if text.trim().is_empty() {
+        return Err(ParseError::Empty);
+    }
+    let Some(rest) = text.strip_prefix('/') else {
+        return Err(ParseError::Invalid);
+    };
+
+    let (name, args) = match rest.find(char::is_whitespace) {
+        Some(idx) => {
+            let (name, tail) = rest.split_at(idx);
+            (name, tail.trim_start())
+        }
+        None => (rest, ""),
+    };
+
+    if name.is_empty()
+        || !name
+            .chars()
+            .next()
+            .is_some_and(|c| c.is_ascii_alphanumeric())
+    {
+        return Err(ParseError::Invalid);
+    }
+
+    Ok(ParsedCommand { name, args })
+}
+
+/// Return true iff the input is a single line starting with `/` (and not `//`).
+///
+/// Used by the TUI to decide whether the completion popup should be active.
+/// Multiline input and the `//` escape sequence both deactivate command mode.
+#[must_use]
+pub fn is_command_mode(text: &str) -> bool {
+    if text.contains('\n') {
+        return false;
+    }
+    if text.starts_with("//") {
+        return false;
+    }
+    text.starts_with('/')
+}
+
+/// If `text` starts with `//`, return the text with one leading `/` removed.
+/// Otherwise return the input unchanged. Called by the send path so that
+/// `//foo` gets sent as the literal message `/foo`.
+#[must_use]
+pub fn strip_escape(text: &str) -> &str {
+    if text.starts_with("//") {
+        &text[1..]
+    } else {
+        text
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_name_only() {
+        let parsed = parse("/tableflip").unwrap();
+        assert_eq!(parsed.name, "tableflip");
+        assert_eq!(parsed.args, "");
+    }
+
+    #[test]
+    fn parse_name_and_args() {
+        let parsed = parse("/shrug hello world").unwrap();
+        assert_eq!(parsed.name, "shrug");
+        assert_eq!(parsed.args, "hello world");
+    }
+
+    #[test]
+    fn parse_preserves_rest_of_line_for_me() {
+        let parsed = parse("/me waves at bob").unwrap();
+        assert_eq!(parsed.name, "me");
+        assert_eq!(parsed.args, "waves at bob");
+    }
+
+    #[test]
+    fn parse_collapses_multiple_spaces_between_name_and_args() {
+        let parsed = parse("/me    waves   at   bob").unwrap();
+        assert_eq!(parsed.name, "me");
+        assert_eq!(parsed.args, "waves   at   bob");
+    }
+
+    #[test]
+    fn parse_empty_returns_empty_error() {
+        assert_eq!(parse("").unwrap_err(), ParseError::Empty);
+    }
+
+    #[test]
+    fn parse_whitespace_returns_empty_error() {
+        assert_eq!(parse("   ").unwrap_err(), ParseError::Empty);
+    }
+
+    #[test]
+    fn parse_just_slash_returns_invalid_error() {
+        assert_eq!(parse("/").unwrap_err(), ParseError::Invalid);
+    }
+
+    #[test]
+    fn parse_slash_space_returns_invalid_error() {
+        assert_eq!(parse("/ foo").unwrap_err(), ParseError::Invalid);
+    }
+
+    #[test]
+    fn parse_missing_leading_slash_returns_invalid() {
+        assert_eq!(parse("tableflip").unwrap_err(), ParseError::Invalid);
+    }
+
+    #[test]
+    fn parse_leading_whitespace_not_allowed() {
+        assert_eq!(parse(" /tableflip").unwrap_err(), ParseError::Invalid);
+    }
+
+    #[test]
+    fn parse_name_is_lowercase_alphanumeric() {
+        let parsed = parse("/help2 arg").unwrap();
+        assert_eq!(parsed.name, "help2");
+        assert_eq!(parsed.args, "arg");
+    }
+
+    #[test]
+    fn parse_trailing_whitespace_in_args_preserved() {
+        let parsed = parse("/me hi   ").unwrap();
+        assert_eq!(parsed.name, "me");
+        assert_eq!(parsed.args, "hi   ");
+    }
+
+    #[test]
+    fn command_mode_active_for_single_line_starting_with_slash() {
+        assert!(is_command_mode("/tableflip"));
+        assert!(is_command_mode("/me waves"));
+        assert!(is_command_mode("/"));
+    }
+
+    #[test]
+    fn command_mode_inactive_for_escape_sequence() {
+        assert!(!is_command_mode("//foo"));
+        assert!(!is_command_mode("//"));
+    }
+
+    #[test]
+    fn command_mode_inactive_for_plain_text() {
+        assert!(!is_command_mode("hello"));
+        assert!(!is_command_mode(""));
+        assert!(!is_command_mode(" /tableflip"));
+    }
+
+    #[test]
+    fn command_mode_inactive_for_multiline_input() {
+        assert!(!is_command_mode("/tableflip\nmore"));
+        assert!(!is_command_mode("/me\n"));
+    }
+
+    #[test]
+    fn strip_escape_removes_leading_slash_from_double_slash() {
+        assert_eq!(strip_escape("//foo"), "/foo");
+        assert_eq!(strip_escape("//"), "/");
+        assert_eq!(strip_escape("//tableflip text"), "/tableflip text");
+    }
+
+    #[test]
+    fn strip_escape_leaves_other_text_unchanged() {
+        assert_eq!(strip_escape("/foo"), "/foo");
+        assert_eq!(strip_escape("hello"), "hello");
+        assert_eq!(strip_escape(""), "");
+        assert_eq!(strip_escape("/"), "/");
+    }
+
+    #[test]
+    fn into_owned_round_trips() {
+        let parsed = parse("/tableflip hello").unwrap();
+        let owned = parsed.into_owned();
+        assert_eq!(owned.name, "tableflip");
+        assert_eq!(owned.args, "hello");
+    }
+}

--- a/apps/client/src/tui/commands/parser.rs
+++ b/apps/client/src/tui/commands/parser.rs
@@ -12,19 +12,22 @@ pub struct ParsedCommand<'a> {
 }
 
 impl ParsedCommand<'_> {
-    /// Convert to a `'static` lifetime by leaking owned strings.
-    ///
-    /// Used by `CompletionOutcome::Dispatch` so the outcome can be passed
-    /// back through `App` without borrowing from the textarea state.
-    /// Leak is bounded: one dispatch per user Enter press, small strings.
-    /// If this ever becomes a memory concern, replace with a
-    /// `ParsedCommandOwned { name: String, args: String }` struct.
     #[must_use]
-    pub fn into_owned(self) -> ParsedCommand<'static> {
-        let name = Box::leak(self.name.to_string().into_boxed_str());
-        let args = Box::leak(self.args.to_string().into_boxed_str());
-        ParsedCommand { name, args }
+    pub fn into_owned(self) -> ParsedCommandOwned {
+        ParsedCommandOwned {
+            name: self.name.to_string(),
+            args: self.args.to_string(),
+        }
     }
+}
+
+/// Owned variant of [`ParsedCommand`] that doesn't borrow from the input.
+/// Carried by [`super::CompletionOutcome::Dispatch`] so the parsed command
+/// can outlive the textarea state it was parsed from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedCommandOwned {
+    pub name: String,
+    pub args: String,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]

--- a/apps/client/src/tui/commands/popup.rs
+++ b/apps/client/src/tui/commands/popup.rs
@@ -83,8 +83,8 @@ impl CommandCompletionState {
             return;
         }
 
-        let (before_space, after_space) = match line.find(char::is_whitespace) {
-            Some(idx) => (&line[..idx], Some(&line[idx + 1..])),
+        let (before_space, after_space) = match line.split_once(char::is_whitespace) {
+            Some((name, rest)) => (name, Some(rest)),
             None => (line, None),
         };
 

--- a/apps/client/src/tui/commands/popup.rs
+++ b/apps/client/src/tui/commands/popup.rs
@@ -1,0 +1,584 @@
+//! Command completion popup: state machine + rendering.
+//!
+//! `CommandCompletionState` is self-contained: `App` owns it as a field and
+//! interacts only through the narrow interface (`is_active`, `handle_key`,
+//! `update_from_input`, `suppress`, `reset`, `tab_insertion`, `render`,
+//! `render_ghost_text`). All command-mode logic lives inside this module.
+//! When the `Component` trait (#172) lands this struct becomes a
+//! straightforward `impl Component` with near-zero migration.
+
+use super::{CompletionEntry, ParsedCommand, Registry};
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::{
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState},
+    Frame,
+};
+
+/// What the app should do after a key has been offered to the popup.
+#[derive(Debug)]
+pub enum CompletionOutcome {
+    /// The textarea should handle this key (e.g. a character or backspace).
+    PassThrough,
+    /// The popup handled the key, no further processing needed.
+    Consumed,
+    /// The user pressed Enter on a parseable command; app should dispatch it.
+    Dispatch(ParsedCommand<'static>),
+    /// The user pressed Esc; app should call `suppress()`.
+    Exit,
+}
+
+pub struct CommandCompletionState {
+    registry: Registry,
+    active: bool,
+    /// Set by `suppress()` (called when the user presses Esc). Blocks
+    /// `update_from_input` from re-activating the popup as long as the
+    /// current input still starts with `/`. Cleared automatically once
+    /// the user deletes the leading slash or empties the input.
+    suppressed: bool,
+    current_line: String,
+    candidates: Vec<CompletionEntry>,
+    selected: usize,
+}
+
+impl CommandCompletionState {
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn new(registry: Registry) -> Self {
+        Self {
+            registry,
+            active: false,
+            suppressed: false,
+            current_line: String::new(),
+            candidates: Vec::new(),
+            selected: 0,
+        }
+    }
+
+    #[must_use]
+    pub const fn is_active(&self) -> bool {
+        self.active
+    }
+
+    /// Re-filter the candidate list from the first textarea line. Called
+    /// after every keystroke that reaches the textarea.
+    pub fn update_from_input(&mut self, line: &str) {
+        self.current_line = line.to_string();
+
+        // Clear suppression once the user deletes back past the '/' or
+        // the line stops starting with '/'. Typing '/' again from an
+        // unsuppressed state re-activates normally.
+        if self.suppressed && !line.starts_with('/') {
+            self.suppressed = false;
+        }
+
+        if self.suppressed {
+            self.active = false;
+            self.candidates.clear();
+            self.selected = 0;
+            return;
+        }
+
+        let was_active = self.active;
+        self.active = super::parser::is_command_mode(line);
+
+        if !self.active {
+            self.candidates.clear();
+            self.selected = 0;
+            return;
+        }
+
+        let (before_space, after_space) = match line.find(char::is_whitespace) {
+            Some(idx) => (&line[..idx], Some(&line[idx + 1..])),
+            None => (line, None),
+        };
+
+        self.candidates = if let Some(args_so_far) = after_space {
+            let name = before_space.strip_prefix('/').unwrap_or(before_space);
+            self.registry
+                .find(name)
+                .map(|cmd| cmd.complete_args(args_so_far))
+                .unwrap_or_default()
+        } else {
+            self.registry.complete(before_space)
+        };
+
+        if !was_active || self.selected >= self.candidates.len() {
+            self.selected = 0;
+        }
+    }
+
+    /// Exit command mode but preserve textarea content. Called by the app
+    /// when the user presses Esc. Blocks re-activation until the user
+    /// deletes the leading `/` — see `update_from_input`.
+    pub fn suppress(&mut self) {
+        self.active = false;
+        self.suppressed = true;
+        self.candidates.clear();
+        self.selected = 0;
+    }
+
+    /// Clear all completion state. Called when the textarea is replaced
+    /// wholesale (e.g. after a successful command dispatch).
+    pub fn reset(&mut self) {
+        self.active = false;
+        self.suppressed = false;
+        self.current_line.clear();
+        self.candidates.clear();
+        self.selected = 0;
+    }
+
+    #[must_use]
+    #[allow(dead_code)]
+    pub fn candidates(&self) -> &[CompletionEntry] {
+        &self.candidates
+    }
+
+    #[must_use]
+    #[allow(dead_code)]
+    pub const fn selected_index(&self) -> usize {
+        self.selected
+    }
+
+    #[must_use]
+    pub fn selected_entry(&self) -> Option<&CompletionEntry> {
+        self.candidates.get(self.selected)
+    }
+
+    /// What Tab should insert into the textarea. Trailing space lets the
+    /// user immediately start typing arguments. Returns `None` when
+    /// inactive or no candidates.
+    #[must_use]
+    pub fn tab_insertion(&self) -> Option<String> {
+        if !self.active {
+            return None;
+        }
+        let entry = self.candidates.get(self.selected)?;
+        Some(format!("{} ", entry.insert))
+    }
+
+    /// Offer a key event to the popup. Consumers: arrow keys drive
+    /// selection, Tab signals "caller should read `tab_insertion`",
+    /// Enter parses current line and returns `Dispatch`, Esc returns
+    /// `Exit`, everything else passes through.
+    pub fn handle_key(&mut self, key: KeyEvent) -> CompletionOutcome {
+        if !self.active {
+            return CompletionOutcome::PassThrough;
+        }
+
+        match key.code {
+            KeyCode::Down => {
+                if !self.candidates.is_empty() {
+                    self.selected = (self.selected + 1) % self.candidates.len();
+                }
+                CompletionOutcome::Consumed
+            }
+            KeyCode::Up => {
+                if !self.candidates.is_empty() {
+                    self.selected = if self.selected == 0 {
+                        self.candidates.len() - 1
+                    } else {
+                        self.selected - 1
+                    };
+                }
+                CompletionOutcome::Consumed
+            }
+            KeyCode::Tab => CompletionOutcome::Consumed,
+            KeyCode::Enter => match super::parser::parse(&self.current_line) {
+                Ok(parsed) => CompletionOutcome::Dispatch(parsed.into_owned()),
+                Err(_) => CompletionOutcome::Consumed,
+            },
+            KeyCode::Esc => CompletionOutcome::Exit,
+            KeyCode::Backspace
+            | KeyCode::Left
+            | KeyCode::Right
+            | KeyCode::Home
+            | KeyCode::End
+            | KeyCode::PageUp
+            | KeyCode::PageDown
+            | KeyCode::BackTab
+            | KeyCode::Delete
+            | KeyCode::Insert
+            | KeyCode::Null
+            | KeyCode::CapsLock
+            | KeyCode::ScrollLock
+            | KeyCode::NumLock
+            | KeyCode::PrintScreen
+            | KeyCode::Pause
+            | KeyCode::Menu
+            | KeyCode::KeypadBegin
+            | KeyCode::F(_)
+            | KeyCode::Char(_)
+            | KeyCode::Media(_)
+            | KeyCode::Modifier(_) => CompletionOutcome::PassThrough,
+        }
+    }
+
+    /// Render the completion popup above the given input area. No-op when
+    /// inactive, empty, or the popup would not fit above `input_area`.
+    pub fn render(&self, frame: &mut Frame, input_area: Rect) {
+        if !self.active || self.candidates.is_empty() {
+            return;
+        }
+
+        let row_count = u16::try_from(self.candidates.len().min(6)).unwrap_or(6);
+        let popup_height = row_count.saturating_add(2); // borders
+        if popup_height > input_area.y {
+            return; // not enough room above the input
+        }
+        let popup_width = input_area.width.min(60);
+        let popup_area = Rect {
+            x: input_area.x,
+            y: input_area.y - popup_height,
+            width: popup_width,
+            height: popup_height,
+        };
+
+        frame.render_widget(Clear, popup_area);
+
+        let items: Vec<ListItem> = self
+            .candidates
+            .iter()
+            .map(|entry| {
+                let label = format!("{:<18}", entry.label);
+                ListItem::new(Line::from(vec![
+                    Span::styled(label, Style::default().fg(Color::Cyan)),
+                    Span::styled(entry.help.clone(), Style::default().fg(Color::DarkGray)),
+                ]))
+            })
+            .collect();
+
+        let list = List::new(items)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::DarkGray))
+                    .title(" Commands "),
+            )
+            .highlight_style(
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            );
+
+        let mut list_state = ListState::default();
+        list_state.select(Some(self.selected));
+        frame.render_stateful_widget(list, popup_area, &mut list_state);
+    }
+
+    /// Render dimmed ghost-text suffix of the selected candidate at the
+    /// given cursor cell. No-op when the typed text doesn't prefix the
+    /// selected candidate, or the cell is out of bounds.
+    pub fn render_ghost_text(&self, frame: &mut Frame, cursor_cell: (u16, u16)) {
+        if !self.active {
+            return;
+        }
+        let Some(entry) = self.selected_entry() else {
+            return;
+        };
+        let Some(suffix) = entry.insert.strip_prefix(self.current_line.as_str()) else {
+            return;
+        };
+        if suffix.is_empty() {
+            return;
+        }
+
+        let (x, y) = cursor_cell;
+        let area = frame.area();
+        if x >= area.width || y >= area.height {
+            return;
+        }
+
+        let available_width = area.width.saturating_sub(x) as usize;
+        let truncated: String = suffix.chars().take(available_width).collect();
+
+        frame
+            .buffer_mut()
+            .set_string(x, y, &truncated, Style::default().fg(Color::DarkGray));
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn state() -> CommandCompletionState {
+        CommandCompletionState::new(Registry::builtin())
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    // ── core state ──────────────────────────────────────────────
+
+    #[test]
+    fn inactive_for_empty_input() {
+        let mut s = state();
+        s.update_from_input("");
+        assert!(!s.is_active());
+        assert!(s.candidates().is_empty());
+    }
+
+    #[test]
+    fn active_when_line_starts_with_slash() {
+        let mut s = state();
+        s.update_from_input("/");
+        assert!(s.is_active());
+        assert_eq!(s.candidates().len(), 6);
+    }
+
+    #[test]
+    fn filters_candidates_on_prefix() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        assert!(s.is_active());
+        assert_eq!(s.candidates().len(), 1);
+        assert_eq!(s.candidates()[0].label, "/tableflip");
+    }
+
+    #[test]
+    fn inactive_for_escape_sequence() {
+        let mut s = state();
+        s.update_from_input("//foo");
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn inactive_for_plain_text() {
+        let mut s = state();
+        s.update_from_input("hello world");
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn deactivate_clears_state() {
+        let mut s = state();
+        s.update_from_input("/tab");
+        assert!(s.is_active());
+        s.update_from_input("hello");
+        assert!(!s.is_active());
+        assert!(s.candidates().is_empty());
+        assert_eq!(s.selected_index(), 0);
+    }
+
+    #[test]
+    fn reset_clears_everything() {
+        let mut s = state();
+        s.update_from_input("/");
+        s.reset();
+        assert!(!s.is_active());
+        assert!(s.candidates().is_empty());
+        assert_eq!(s.selected_index(), 0);
+    }
+
+    #[test]
+    fn selected_clamps_when_candidates_shrink() {
+        let mut s = state();
+        s.update_from_input("/");
+        s.update_from_input("/tab"); // one candidate
+        assert!(s.selected_index() < s.candidates().len());
+    }
+
+    // ── suppression ─────────────────────────────────────────────
+
+    #[test]
+    fn suppress_disables_activation_while_line_still_starts_with_slash() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        assert!(s.is_active());
+
+        s.suppress();
+        assert!(!s.is_active());
+        assert!(s.candidates().is_empty());
+
+        s.update_from_input("/tab");
+        assert!(!s.is_active(), "still suppressed while '/' remains");
+        s.update_from_input("/table");
+        assert!(!s.is_active());
+    }
+
+    #[test]
+    fn suppress_clears_once_input_loses_leading_slash() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        s.suppress();
+
+        s.update_from_input("");
+        assert!(!s.is_active());
+
+        s.update_from_input("/");
+        assert!(s.is_active());
+    }
+
+    #[test]
+    fn suppress_clears_when_input_becomes_plain_text() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        s.suppress();
+
+        s.update_from_input("hello");
+        assert!(!s.is_active());
+        s.update_from_input("hello /world");
+        assert!(!s.is_active());
+    }
+
+    // ── handle_key ──────────────────────────────────────────────
+
+    #[test]
+    fn passes_through_when_inactive() {
+        let mut s = state();
+        let outcome = s.handle_key(key(KeyCode::Char('a')));
+        assert!(matches!(outcome, CompletionOutcome::PassThrough));
+    }
+
+    #[test]
+    fn down_advances_selection() {
+        let mut s = state();
+        s.update_from_input("/");
+        assert_eq!(s.selected_index(), 0);
+        let _ = s.handle_key(key(KeyCode::Down));
+        assert_eq!(s.selected_index(), 1);
+    }
+
+    #[test]
+    fn down_wraps_at_end() {
+        let mut s = state();
+        s.update_from_input("/");
+        let last = s.candidates().len() - 1;
+        for _ in 0..last {
+            let _ = s.handle_key(key(KeyCode::Down));
+        }
+        assert_eq!(s.selected_index(), last);
+        let _ = s.handle_key(key(KeyCode::Down));
+        assert_eq!(s.selected_index(), 0);
+    }
+
+    #[test]
+    fn up_retreats_with_wrap() {
+        let mut s = state();
+        s.update_from_input("/");
+        let last = s.candidates().len() - 1;
+        let _ = s.handle_key(key(KeyCode::Up));
+        assert_eq!(s.selected_index(), last);
+    }
+
+    #[test]
+    fn arrow_is_consumed_when_active() {
+        let mut s = state();
+        s.update_from_input("/");
+        let outcome = s.handle_key(key(KeyCode::Down));
+        assert!(matches!(outcome, CompletionOutcome::Consumed));
+    }
+
+    #[test]
+    fn tab_returns_consumed_without_dispatching() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        let outcome = s.handle_key(key(KeyCode::Tab));
+        assert!(matches!(outcome, CompletionOutcome::Consumed));
+    }
+
+    #[test]
+    fn enter_returns_dispatch_with_parsed_command() {
+        let mut s = state();
+        s.update_from_input("/tableflip hi");
+        let outcome = s.handle_key(key(KeyCode::Enter));
+        match outcome {
+            CompletionOutcome::Dispatch(parsed) => {
+                assert_eq!(parsed.name, "tableflip");
+                assert_eq!(parsed.args, "hi");
+            }
+            other @ (CompletionOutcome::PassThrough
+            | CompletionOutcome::Consumed
+            | CompletionOutcome::Exit) => panic!("expected Dispatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn enter_on_unknown_command_still_dispatches() {
+        let mut s = state();
+        s.update_from_input("/nonsense");
+        let outcome = s.handle_key(key(KeyCode::Enter));
+        assert!(matches!(outcome, CompletionOutcome::Dispatch(_)));
+    }
+
+    #[test]
+    fn esc_returns_exit() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        let outcome = s.handle_key(key(KeyCode::Esc));
+        assert!(matches!(outcome, CompletionOutcome::Exit));
+    }
+
+    #[test]
+    fn passthrough_for_character_keys_when_active() {
+        let mut s = state();
+        s.update_from_input("/");
+        let outcome = s.handle_key(key(KeyCode::Char('a')));
+        assert!(matches!(outcome, CompletionOutcome::PassThrough));
+    }
+
+    #[test]
+    fn passthrough_for_backspace_when_active() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        let outcome = s.handle_key(key(KeyCode::Backspace));
+        assert!(matches!(outcome, CompletionOutcome::PassThrough));
+    }
+
+    // ── tab_insertion ───────────────────────────────────────────
+
+    #[test]
+    fn tab_insertion_returns_selected_entry_with_trailing_space() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        assert_eq!(s.tab_insertion(), Some("/tableflip ".to_string()));
+    }
+
+    #[test]
+    fn tab_insertion_uses_selected_index() {
+        let mut s = state();
+        s.update_from_input("/");
+        // First candidate alphabetically is /clear.
+        assert_eq!(s.tab_insertion(), Some("/clear ".to_string()));
+    }
+
+    #[test]
+    fn tab_insertion_empty_when_inactive() {
+        let s = state();
+        assert_eq!(s.tab_insertion(), None);
+    }
+
+    #[test]
+    fn tab_insertion_empty_when_no_candidates() {
+        let mut s = state();
+        s.update_from_input("/xyz");
+        assert_eq!(s.tab_insertion(), None);
+    }
+
+    // ── ghost text ──────────────────────────────────────────────
+
+    #[test]
+    fn ghost_suffix_is_selected_entry_minus_current_input() {
+        let mut s = state();
+        s.update_from_input("/ta");
+        let entry = s.selected_entry().unwrap();
+        let suffix = entry.insert.strip_prefix("/ta").unwrap();
+        assert_eq!(suffix, "bleflip");
+    }
+
+    #[test]
+    fn ghost_suffix_empty_when_full_command_typed() {
+        let mut s = state();
+        s.update_from_input("/tableflip");
+        let entry = s.selected_entry().unwrap();
+        let suffix = entry.insert.strip_prefix("/tableflip").unwrap();
+        assert_eq!(suffix, "");
+    }
+}

--- a/apps/client/src/tui/commands/popup.rs
+++ b/apps/client/src/tui/commands/popup.rs
@@ -179,10 +179,19 @@ impl CommandCompletionState {
                 CompletionOutcome::Consumed
             }
             KeyCode::Tab => CompletionOutcome::Consumed,
-            KeyCode::Enter => match super::parser::parse(&self.current_line) {
-                Ok(parsed) => CompletionOutcome::Dispatch(parsed.into_owned()),
-                Err(_) => CompletionOutcome::Consumed,
-            },
+            KeyCode::Enter => {
+                // Prefer the selected popup entry over the raw typed text.
+                // User types "/cl", arrows to "/clear", presses Enter → dispatch /clear.
+                if let Some(entry) = self.selected_entry() {
+                    if let Ok(parsed) = super::parser::parse(&entry.insert) {
+                        return CompletionOutcome::Dispatch(parsed.into_owned());
+                    }
+                }
+                match super::parser::parse(&self.current_line) {
+                    Ok(parsed) => CompletionOutcome::Dispatch(parsed.into_owned()),
+                    Err(_) => CompletionOutcome::Consumed,
+                }
+            }
             KeyCode::Esc => CompletionOutcome::Exit,
             KeyCode::Backspace
             | KeyCode::Left
@@ -221,7 +230,7 @@ impl CommandCompletionState {
         if popup_height > input_area.y {
             return; // not enough room above the input
         }
-        let popup_width = input_area.width.min(60);
+        let popup_width = input_area.width;
         let popup_area = Rect {
             x: input_area.x,
             y: input_area.y - popup_height,

--- a/apps/client/src/tui/commands/popup.rs
+++ b/apps/client/src/tui/commands/popup.rs
@@ -90,10 +90,19 @@ impl CommandCompletionState {
 
         self.candidates = if let Some(args_so_far) = after_space {
             let name = before_space.strip_prefix('/').unwrap_or(before_space);
-            self.registry
+            let args = self
+                .registry
                 .find(name)
                 .map(|cmd| cmd.complete_args(args_so_far))
-                .unwrap_or_default()
+                .unwrap_or_default();
+            // No arg completions available — deactivate so Tab/Esc aren't
+            // swallowed by an invisible popup.
+            if args.is_empty() {
+                self.active = false;
+                self.selected = 0;
+                return;
+            }
+            args
         } else {
             self.registry.complete(before_space)
         };
@@ -140,9 +149,9 @@ impl CommandCompletionState {
         self.candidates.get(self.selected)
     }
 
-    /// What Tab should insert into the textarea. Trailing space lets the
-    /// user immediately start typing arguments. Returns `None` when
+    /// What Tab should insert into the textarea. Returns `None` when
     /// inactive or no candidates.
+    // TODO(#232): only append trailing space when the command accepts args
     #[must_use]
     pub fn tab_insertion(&self) -> Option<String> {
         if !self.active {
@@ -487,14 +496,14 @@ mod tests {
     }
 
     #[test]
-    fn enter_returns_dispatch_with_parsed_command() {
+    fn enter_dispatches_selected_entry() {
         let mut s = state();
-        s.update_from_input("/tableflip hi");
+        s.update_from_input("/ta");
         let outcome = s.handle_key(key(KeyCode::Enter));
         match outcome {
             CompletionOutcome::Dispatch(parsed) => {
                 assert_eq!(parsed.name, "tableflip");
-                assert_eq!(parsed.args, "hi");
+                assert_eq!(parsed.args, "");
             }
             other @ (CompletionOutcome::PassThrough
             | CompletionOutcome::Consumed
@@ -508,6 +517,21 @@ mod tests {
         s.update_from_input("/nonsense");
         let outcome = s.handle_key(key(KeyCode::Enter));
         assert!(matches!(outcome, CompletionOutcome::Dispatch(_)));
+    }
+
+    #[test]
+    fn popup_deactivates_when_arg_completion_is_empty() {
+        let mut s = state();
+        s.update_from_input("/help ");
+        assert!(
+            !s.is_active(),
+            "no arg completions → popup should deactivate"
+        );
+        let outcome = s.handle_key(key(KeyCode::Tab));
+        assert!(
+            matches!(outcome, CompletionOutcome::PassThrough),
+            "Tab should pass through when popup is inactive"
+        );
     }
 
     #[test]

--- a/apps/client/src/tui/commands/popup.rs
+++ b/apps/client/src/tui/commands/popup.rs
@@ -1,13 +1,6 @@
 //! Command completion popup: state machine + rendering.
-//!
-//! `CommandCompletionState` is self-contained: `App` owns it as a field and
-//! interacts only through the narrow interface (`is_active`, `handle_key`,
-//! `update_from_input`, `suppress`, `reset`, `tab_insertion`, `render`,
-//! `render_ghost_text`). All command-mode logic lives inside this module.
-//! When the `Component` trait (#172) lands this struct becomes a
-//! straightforward `impl Component` with near-zero migration.
 
-use super::{CompletionEntry, ParsedCommand, Registry};
+use super::{CompletionEntry, ParsedCommandOwned, Registry};
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
     layout::Rect,
@@ -25,7 +18,7 @@ pub enum CompletionOutcome {
     /// The popup handled the key, no further processing needed.
     Consumed,
     /// The user pressed Enter on a parseable command; app should dispatch it.
-    Dispatch(ParsedCommand<'static>),
+    Dispatch(ParsedCommandOwned),
     /// The user pressed Esc; app should call `suppress()`.
     Exit,
 }

--- a/apps/client/src/tui/mod.rs
+++ b/apps/client/src/tui/mod.rs
@@ -6,6 +6,7 @@
 //! - Input area at the bottom
 
 mod app;
+mod commands;
 pub mod conversation_list;
 mod event;
 pub mod http_server;

--- a/apps/client/src/tui/ui.rs
+++ b/apps/client/src/tui/ui.rs
@@ -187,6 +187,20 @@ fn render_input(frame: &mut Frame, app: &App, area: Rect) {
 
     // Render the textarea widget
     frame.render_widget(&app.input, inner);
+
+    // Slash command completion popup (rendered above the input area).
+    app.command_completion.render(frame, area);
+
+    // Ghost text overlay: dimmed suffix of the selected completion candidate.
+    let (row, col) = app.input.cursor();
+    if row == 0 {
+        let cursor_x = inner
+            .x
+            .saturating_add(u16::try_from(col).unwrap_or(u16::MAX));
+        let cursor_y = inner.y;
+        app.command_completion
+            .render_ghost_text(frame, (cursor_x, cursor_y));
+    }
 }
 
 /// Render the status bar


### PR DESCRIPTION
## Summary

- Add a `commands/` module under `apps/client/src/tui/` with a `Command` trait, `Registry`, parser, name+alias completion engine, and a `CommandCompletionState` popup/ghost-text state machine
- Ship six cosmetic commands: `/help`, `/tableflip`, `/shrug` (alias `/sh`), `/me`, `/clear`, `/quit`
- Autocomplete popup with arrow navigation, Tab insertion, ghost-text overlay, and Esc suppression gate
- Escape sequence `//foo` sends literal `/foo`
- `/help <name>` resolves command-specific usage via app-level dispatch
- `/clear` empties both visible scrollback and the in-memory cache entry for the selected contact (does not touch persistent storage)

Framework extension hooks (`CommandAction::BackendCall`, `StartEphemeralSession`) are reserved as commented variants for follow-up PRs (#232 local-action commands, #233 ephemeral P2P sessions).

## Architecture

New module at `apps/client/src/tui/commands/` with five files: `mod.rs` (trait, registry, types), `parser.rs`, `complete.rs`, `builtin.rs`, `popup.rs`. `CommandCompletionState` exposes a narrow interface (`is_active`, `handle_key`, `update_from_input`, `suppress`, `reset`, `tab_insertion`, `render`, `render_ghost_text`) — `App` delegates through it, keeping command-mode logic out of `app.rs`. Key interception lives in `handle_key_event` before the global Esc/Tab focus-switch block, gated on `Focus::Input && command_completion.is_active()`.

## Review passes incorporated

- **Codex adversarial review**: fixed key routing order (interception before Esc/Tab trap), `/help <name>` dispatch, `/clear` cache semantics, Esc suppression gate
- **Simplify pass**: extracted `App::fresh_input()`, replaced `Box::leak` with `ParsedCommandOwned`, narrowed field visibility, trimmed comments
- **Parallel review fan-out** (Codex + code-review agent + spec-review agent): fixed multi-byte whitespace panic in `update_from_input`, added alias matching to completion, fixed multiline paste misinterpretation, verified all 6 spec architectural decisions
- **Smoke test feedback**: popup uses full input width (no truncation), Enter dispatches the selected popup entry (not the raw typed prefix)

Closes #231

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a slash-command framework to the TUI with an autocomplete popup and ghost-text, plus six client-local commands for quick actions. Improves input UX with arrow/Tab navigation, Enter-to-dispatch, and an Esc suppression gate; supports `//` to send a literal slash.

- **New Features**
  - Command framework: `Command` trait, `Registry`, parser (`parse`, `is_command_mode`, `strip_escape`), and a completion state machine.
  - Six commands: `/help`, `/tableflip`, `/shrug` (alias `/sh`), `/me`, `/clear`, `/quit`.
  - Autocomplete popup above the input: arrow navigation, Tab insertion with trailing space, ghost-text suffix, Enter dispatches the selected entry, Esc hides without clearing text.
  - Command behavior: `//foo` sends "/foo"; `/help <name>` shows command-specific usage; `/clear` clears visible scrollback and the in-memory cache for the selected contact.

- **Bug Fixes**
  - Key routing fixed: popup intercepts keys before the global Esc/Tab focus handler.
  - Completion improvements: matches aliases, uses full input width, Enter picks the highlighted match.
  - Robust input handling: fixed multi-byte whitespace panic; multiline pastes correctly disable command mode.
  - Popup deactivates when arg-completion is empty so Tab/Esc pass through; `/help <name>` strips a leading `/` in the target; removed a small leak by using `ParsedCommandOwned`; deduped input resets via `fresh_input`.

<sup>Written for commit 5544b76c48036b9633cfbe34a005066f27612751. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced slash command system with built-in commands: /tableflip, /shrug (alias: sh), /me, /clear, /quit, and /help for quick actions.
  * Added command autocomplete with a popup menu displaying matching commands and their descriptions.
  * Enabled keyboard navigation (arrow keys) and Tab insertion for faster command entry.
  * Added ghost-text preview showing command completion suggestions as you type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->