### PR TITLE
refactor(tui): adopt ratatui-macros for layout code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "percent-encoding",
  "postcard",
  "rand 0.9.2",
- "ratatui",
+ "ratatui 0.29.0",
  "ratatui-macros",
  "reqwest",
  "rpassword",
@@ -570,20 +570,6 @@ name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -2014,15 +2000,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2060,16 +2037,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kasuari"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
-dependencies = [
- "hashbrown 0.16.1",
- "thiserror 2.0.17",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,15 +2067,6 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
-]
-
-[[package]]
-name = "line-clipping"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2151,15 +2109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
-dependencies = [
- "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2833,72 +2782,53 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",
- "compact_str 0.8.1",
+ "compact_str",
  "crossterm",
  "indoc",
  "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
+ "itertools",
+ "lru",
  "paste",
  "strum 0.26.3",
  "unicode-segmentation",
- "unicode-truncate 1.1.0",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "ratatui-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
-dependencies = [
- "bitflags",
- "compact_str 0.9.0",
- "hashbrown 0.16.1",
- "indoc",
- "itertools 0.14.0",
- "kasuari",
- "lru 0.16.4",
- "strum 0.27.2",
- "thiserror 2.0.17",
- "unicode-segmentation",
- "unicode-truncate 2.0.1",
+ "unicode-truncate",
  "unicode-width 0.2.0",
 ]
 
 [[package]]
 name = "ratatui-macros"
-version = "0.7.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+checksum = "142d72442aff1ba834b80f50a22a48302e665e90b3a43eaab52bf99b037df0c0"
 dependencies = [
- "ratatui-core",
- "ratatui-widgets",
-]
-
-[[package]]
-name = "ratatui-widgets"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
-dependencies = [
- "bitflags",
- "hashbrown 0.16.1",
- "indoc",
- "instability",
- "itertools 0.14.0",
- "line-clipping",
- "ratatui-core",
- "strum 0.27.2",
- "time",
- "unicode-segmentation",
- "unicode-width 0.2.0",
+ "ratatui 0.28.1",
 ]
 
 [[package]]
@@ -4026,7 +3956,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
 dependencies = [
  "crossterm",
- "ratatui",
+ "ratatui 0.29.0",
  "unicode-width 0.2.0",
 ]
 
@@ -4060,20 +3990,9 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools 0.13.0",
+ "itertools",
  "unicode-segmentation",
  "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "unicode-truncate"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
-dependencies = [
- "itertools 0.14.0",
- "unicode-segmentation",
- "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,7 +521,7 @@ dependencies = [
  "percent-encoding",
  "postcard",
  "rand 0.9.2",
- "ratatui 0.29.0",
+ "ratatui",
  "ratatui-macros",
  "reqwest",
  "rpassword",
@@ -2782,27 +2782,6 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
-dependencies = [
- "bitflags",
- "cassowary",
- "compact_str",
- "crossterm",
- "instability",
- "itertools",
- "lru",
- "paste",
- "strum 0.26.3",
- "strum_macros 0.26.4",
- "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
@@ -2824,11 +2803,11 @@ dependencies = [
 
 [[package]]
 name = "ratatui-macros"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142d72442aff1ba834b80f50a22a48302e665e90b3a43eaab52bf99b037df0c0"
+checksum = "6fef540f80dbe8a0773266fa6077788ceb65ef624cdbf36e131aaf90b4a52df4"
 dependencies = [
- "ratatui 0.28.1",
+ "ratatui",
 ]
 
 [[package]]
@@ -3956,7 +3935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
 dependencies = [
  "crossterm",
- "ratatui 0.29.0",
+ "ratatui",
  "unicode-width 0.2.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -522,6 +522,7 @@ dependencies = [
  "postcard",
  "rand 0.9.2",
  "ratatui",
+ "ratatui-macros",
  "reqwest",
  "rpassword",
  "serde",
@@ -569,6 +570,20 @@ name = "compact_str"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -1999,6 +2014,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2036,6 +2060,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.17",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2066,6 +2100,15 @@ dependencies = [
  "cc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -2108,6 +2151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2787,16 +2839,65 @@ checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
  "bitflags",
  "cassowary",
- "compact_str",
+ "compact_str 0.8.1",
  "crossterm",
  "indoc",
  "instability",
- "itertools",
- "lru",
+ "itertools 0.13.0",
+ "lru 0.12.5",
  "paste",
  "strum 0.26.3",
  "unicode-segmentation",
- "unicode-truncate",
+ "unicode-truncate 1.1.0",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags",
+ "compact_str 0.9.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.16.4",
+ "strum 0.27.2",
+ "thiserror 2.0.17",
+ "unicode-segmentation",
+ "unicode-truncate 2.0.1",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -3959,9 +4060,20 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
 dependencies = [
- "itertools",
+ "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
+dependencies = [
+ "itertools 0.14.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,7 @@ chacha20poly1305 = "^0.10.1"
 ratatui = "^0.29"
 crossterm = "^0.28"
 tui-textarea = "^0.7"
+ratatui-macros = "^0.7"
 
 # Workspace-wide lint configuration
 # All crates should add `[lints] workspace = true` to inherit these

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ chacha20poly1305 = "^0.10.1"
 ratatui = "^0.29"
 crossterm = "^0.28"
 tui-textarea = "^0.7"
-ratatui-macros = "^0.7"
+ratatui-macros = "^0.5"
 
 # Workspace-wide lint configuration
 # All crates should add `[lints] workspace = true` to inherit these

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ chacha20poly1305 = "^0.10.1"
 ratatui = "^0.29"
 crossterm = "^0.28"
 tui-textarea = "^0.7"
-ratatui-macros = "^0.5"
+ratatui-macros = "^0.6"
 
 # Workspace-wide lint configuration
 # All crates should add `[lints] workspace = true` to inherit these

--- a/apps/client/Cargo.toml
+++ b/apps/client/Cargo.toml
@@ -54,6 +54,7 @@ directories = { workspace = true }
 
 # TUI
 ratatui = { workspace = true }
+ratatui-macros = { workspace = true }
 crossterm = { workspace = true, features = ["event-stream"] }
 tui-textarea = { workspace = true }
 

--- a/apps/client/src/tui/ui.rs
+++ b/apps/client/src/tui/ui.rs
@@ -12,6 +12,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
     Frame,
 };
+use ratatui_macros::{horizontal, vertical};
 
 use super::app::{AddContactField, AddUpstreamField, App, DeliveryStatus, Focus, UpstreamType};
 use ember_transport::DeliveryTier;
@@ -29,22 +30,13 @@ pub fn render(frame: &mut Frame, app: &mut App) {
     };
 
     // Main layout: conversations (1/3) | messages (2/3)
-    let main_chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Ratio(1, 3), Constraint::Ratio(2, 3)])
-        .split(main_area);
-
-    // Left panel: conversations
-    render_conversations(frame, app, main_chunks[0]);
+    let [conversations_area, right_area] = horizontal![==1/3, ==2/3].areas(main_area);
+    render_conversations(frame, app, conversations_area);
 
     // Right panel: messages + input
-    let right_chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(3), Constraint::Length(3)])
-        .split(main_chunks[1]);
-
-    render_messages(frame, app, right_chunks[0]);
-    render_input(frame, app, right_chunks[1]);
+    let [messages_area, input_area] = vertical![>=3, ==3].areas(right_area);
+    render_messages(frame, app, messages_area);
+    render_input(frame, app, input_area);
 
     // Status bar at the very bottom
     render_status(frame, app);

--- a/apps/client/src/tui/ui.rs
+++ b/apps/client/src/tui/ui.rs
@@ -253,24 +253,15 @@ fn render_add_contact_popup(frame: &mut Frame, app: &App) {
     frame.render_widget(popup_block, area);
 
     // Layout inside popup: instructions, public_id field, name field, error, buttons
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([
-            Constraint::Length(1), // Instructions
-            Constraint::Length(3), // Public ID label + input
-            Constraint::Length(3), // Name label + input
-            Constraint::Length(1), // Error message area
-            Constraint::Length(1), // Button hints
-        ])
-        .split(inner);
+    let [instructions_area, public_id_area, name_area, error_area, hints_area] =
+        vertical![==1, ==3, ==3, ==1, ==1].margin(1).areas(inner);
 
     // Instructions
     let instructions =
         Paragraph::new("Enter contact's Public ID (64-char hex) and optional display name")
             .style(Style::default().fg(Color::DarkGray))
             .wrap(Wrap { trim: true });
-    frame.render_widget(instructions, chunks[0]);
+    frame.render_widget(instructions, instructions_area);
 
     // Public ID field
     let public_id_focused = app.add_contact_popup.focused_field == AddContactField::PublicId;
@@ -283,8 +274,8 @@ fn render_add_contact_popup(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_style(public_id_border_style)
         .title(" Public ID (required) ");
-    let public_id_inner = public_id_block.inner(chunks[1]);
-    frame.render_widget(public_id_block, chunks[1]);
+    let public_id_inner = public_id_block.inner(public_id_area);
+    frame.render_widget(public_id_block, public_id_area);
     frame.render_widget(&app.add_contact_popup.public_id_input, public_id_inner);
 
     // Name field
@@ -298,8 +289,8 @@ fn render_add_contact_popup(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_style(name_border_style)
         .title(" Name (optional) ");
-    let name_inner = name_block.inner(chunks[2]);
-    frame.render_widget(name_block, chunks[2]);
+    let name_inner = name_block.inner(name_area);
+    frame.render_widget(name_block, name_area);
     frame.render_widget(&app.add_contact_popup.name_input, name_inner);
 
     // Error message
@@ -307,14 +298,14 @@ fn render_add_contact_popup(frame: &mut Frame, app: &App) {
         let error_text = Paragraph::new(error.as_str())
             .style(Style::default().fg(Color::Red))
             .wrap(Wrap { trim: true });
-        frame.render_widget(error_text, chunks[3]);
+        frame.render_widget(error_text, error_area);
     }
 
     // Button hints
     let hints = Paragraph::new("Tab: switch field | Enter: confirm | Esc: cancel")
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
-    frame.render_widget(hints, chunks[4]);
+    frame.render_widget(hints, hints_area);
 }
 
 /// Render the "My Identity" popup

--- a/apps/client/src/tui/ui.rs
+++ b/apps/client/src/tui/ui.rs
@@ -6,7 +6,7 @@
 //! - Input area at the bottom
 
 use ratatui::{
-    layout::{Alignment, Constraint, Direction, Flex, Layout, Rect},
+    layout::{Alignment, Constraint, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
@@ -548,22 +548,14 @@ fn render_upstreams_popup(frame: &mut Frame, app: &App) {
     frame.render_widget(popup_block, area);
 
     // Layout inside popup
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([
-            Constraint::Min(1),    // Upstream list
-            Constraint::Length(2), // Legend (2 lines for health + tier)
-            Constraint::Length(1), // Hints
-        ])
-        .split(inner);
+    let [list_area, legend_area, hints_area] = vertical![>=1, ==2, ==1].margin(1).areas(inner);
 
     // Build upstream list
     if targets.is_empty() {
         let empty_text = Paragraph::new("No upstreams configured")
             .style(Style::default().fg(Color::DarkGray))
             .alignment(Alignment::Center);
-        frame.render_widget(empty_text, chunks[0]);
+        frame.render_widget(empty_text, list_area);
     } else {
         let items: Vec<ListItem> = targets
             .iter()
@@ -642,7 +634,7 @@ fn render_upstreams_popup(frame: &mut Frame, app: &App) {
             .collect();
 
         let list = List::new(items);
-        frame.render_widget(list, chunks[0]);
+        frame.render_widget(list, list_area);
     }
 
     // Legend: health + tier explanations (2 lines)
@@ -667,11 +659,11 @@ fn render_upstreams_popup(frame: &mut Frame, app: &App) {
         ]),
     ];
     let legend_para = Paragraph::new(legend_lines).alignment(Alignment::Center);
-    frame.render_widget(legend_para, chunks[1]);
+    frame.render_widget(legend_para, legend_area);
 
     // Hints
     let hints = Paragraph::new("Esc to close")
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
-    frame.render_widget(hints, chunks[2]);
+    frame.render_widget(hints, hints_area);
 }

--- a/apps/client/src/tui/ui.rs
+++ b/apps/client/src/tui/ui.rs
@@ -326,28 +326,20 @@ fn render_my_id_popup(frame: &mut Frame, app: &App) {
     frame.render_widget(popup_block, area);
 
     // Layout inside popup
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([
-            Constraint::Length(1), // Label
-            Constraint::Length(3), // Public ID (with border)
-            Constraint::Length(1), // Hints
-        ])
-        .split(inner);
+    let [label_area, id_area, hints_area] = vertical![==1, ==3, ==1].margin(1).areas(inner);
 
     // Label
     let label = Paragraph::new("Your Public ID (share with others):")
         .style(Style::default().fg(Color::White));
-    frame.render_widget(label, chunks[0]);
+    frame.render_widget(label, label_area);
 
     // Full Public ID in a bordered box for easy copying
     let full_id = app.my_full_id();
     let id_block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::Yellow));
-    let id_inner = id_block.inner(chunks[1]);
-    frame.render_widget(id_block, chunks[1]);
+    let id_inner = id_block.inner(id_area);
+    frame.render_widget(id_block, id_area);
 
     let id_text = Paragraph::new(full_id)
         .style(
@@ -362,7 +354,7 @@ fn render_my_id_popup(frame: &mut Frame, app: &App) {
     let hints = Paragraph::new("Esc to close")
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
-    frame.render_widget(hints, chunks[2]);
+    frame.render_widget(hints, hints_area);
 }
 
 /// Render the add upstream popup

--- a/apps/client/src/tui/ui.rs
+++ b/apps/client/src/tui/ui.rs
@@ -379,24 +379,16 @@ fn render_add_upstream_popup(frame: &mut Frame, app: &App) {
     frame.render_widget(popup_block, area);
 
     // Layout inside popup: instructions, type selector, tier selector, URL field, error, buttons
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .margin(1)
-        .constraints([
-            Constraint::Length(1), // Instructions
-            Constraint::Length(3), // Type selector
-            Constraint::Length(3), // Tier selector
-            Constraint::Length(3), // URL input
-            Constraint::Length(1), // Error message area
-            Constraint::Length(1), // Button hints
-        ])
-        .split(inner);
+    let [instructions_area, type_area, tier_area, url_area, error_area, hints_area] =
+        vertical![==1, ==3, ==3, ==3, ==1, ==1]
+            .margin(1)
+            .areas(inner);
 
     // Instructions
     let instructions = Paragraph::new("Add HTTP or MQTT upstream for this session")
         .style(Style::default().fg(Color::DarkGray))
         .wrap(Wrap { trim: true });
-    frame.render_widget(instructions, chunks[0]);
+    frame.render_widget(instructions, instructions_area);
 
     // Type selector
     let type_focused = app.add_upstream_popup.focused_field == AddUpstreamField::Type;
@@ -435,8 +427,8 @@ fn render_add_upstream_popup(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_style(type_border_style)
         .title(" Type (←/→ to switch) ");
-    let type_inner = type_block.inner(chunks[1]);
-    frame.render_widget(type_block, chunks[1]);
+    let type_inner = type_block.inner(type_area);
+    frame.render_widget(type_block, type_area);
 
     let type_selector = Paragraph::new(type_line).alignment(Alignment::Center);
     frame.render_widget(type_selector, type_inner);
@@ -489,8 +481,8 @@ fn render_add_upstream_popup(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_style(tier_border_style)
         .title(" Tier (←/→ to switch) ");
-    let tier_inner = tier_block.inner(chunks[2]);
-    frame.render_widget(tier_block, chunks[2]);
+    let tier_inner = tier_block.inner(tier_area);
+    frame.render_widget(tier_block, tier_area);
 
     let tier_selector = Paragraph::new(tier_line).alignment(Alignment::Center);
     frame.render_widget(tier_selector, tier_inner);
@@ -506,8 +498,8 @@ fn render_add_upstream_popup(frame: &mut Frame, app: &App) {
         .borders(Borders::ALL)
         .border_style(url_border_style)
         .title(" URL ");
-    let url_inner = url_block.inner(chunks[3]);
-    frame.render_widget(url_block, chunks[3]);
+    let url_inner = url_block.inner(url_area);
+    frame.render_widget(url_block, url_area);
     frame.render_widget(&app.add_upstream_popup.url_input, url_inner);
 
     // Error message
@@ -515,14 +507,14 @@ fn render_add_upstream_popup(frame: &mut Frame, app: &App) {
         let error_text = Paragraph::new(error.as_str())
             .style(Style::default().fg(Color::Red))
             .wrap(Wrap { trim: true });
-        frame.render_widget(error_text, chunks[4]);
+        frame.render_widget(error_text, error_area);
     }
 
     // Button hints
     let hints = Paragraph::new("Tab: switch | ←/→: select | Enter: add | Esc: cancel")
         .style(Style::default().fg(Color::DarkGray))
         .alignment(Alignment::Center);
-    frame.render_widget(hints, chunks[5]);
+    frame.render_widget(hints, hints_area);
 }
 
 /// Render the view upstreams popup

--- a/apps/node/src/config.rs
+++ b/apps/node/src/config.rs
@@ -629,12 +629,10 @@ pub fn load_config_from(
         .unwrap_or_else(|_| defaults.bind_addr.clone());
     let max_messages: usize = config
         .get::<i64>("max_messages")
-        .map(i64_to_usize_clamped)
-        .unwrap_or(defaults.max_messages);
+        .map_or(defaults.max_messages, i64_to_usize_clamped);
     let default_ttl: u32 = config
         .get::<i64>("default_ttl")
-        .map(i64_to_u32_clamped)
-        .unwrap_or(defaults.default_ttl);
+        .map_or(defaults.default_ttl, i64_to_u32_clamped);
     let log_level: String = config
         .get("log_level")
         .unwrap_or_else(|_| defaults.log_level.clone());
@@ -644,12 +642,10 @@ pub fn load_config_from(
     let storage_path: Option<String> = config.get("storage_path").ok();
     let max_body_size: usize = config
         .get::<i64>("max_body_size")
-        .map(i64_to_usize_clamped)
-        .unwrap_or(defaults.max_body_size);
+        .map_or(defaults.max_body_size, i64_to_usize_clamped);
     let max_batch_size: u32 = config
         .get::<i64>("max_batch_size")
-        .map(i64_to_u32_clamped)
-        .unwrap_or(defaults.max_batch_size);
+        .map_or(defaults.max_batch_size, i64_to_u32_clamped);
     let allow_insecure_destination = config
         .get::<bool>("allow_insecure_destination")
         .unwrap_or(false);
@@ -828,20 +824,16 @@ fn extract_cleanup(config: &Config, defaults: &NodeConfig) -> CleanupConfig {
             .unwrap_or(defaults.cleanup.enabled),
         interval_secs: config
             .get::<i64>("cleanup.interval_secs")
-            .map(i64_to_u64_clamped)
-            .unwrap_or(defaults.cleanup.interval_secs),
+            .map_or(defaults.cleanup.interval_secs, i64_to_u64_clamped),
         tombstone_delay_secs: config
             .get::<i64>("cleanup.tombstone_delay_secs")
-            .map(i64_to_u64_clamped)
-            .unwrap_or(defaults.cleanup.tombstone_delay_secs),
+            .map_or(defaults.cleanup.tombstone_delay_secs, i64_to_u64_clamped),
         orphan_delay_secs: config
             .get::<i64>("cleanup.orphan_delay_secs")
-            .map(i64_to_u64_clamped)
-            .unwrap_or(defaults.cleanup.orphan_delay_secs),
+            .map_or(defaults.cleanup.orphan_delay_secs, i64_to_u64_clamped),
         rate_limit_delay_secs: config
             .get::<i64>("cleanup.rate_limit_delay_secs")
-            .map(i64_to_u64_clamped)
-            .unwrap_or(defaults.cleanup.rate_limit_delay_secs),
+            .map_or(defaults.cleanup.rate_limit_delay_secs, i64_to_u64_clamped),
     }
 }
 
@@ -868,36 +860,28 @@ fn extract_rate_limit(
     let mut rl = RateLimitConfig {
         submit_ip_rps: config
             .get::<i64>("rate_limit.submit_ip_rps")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.submit_ip_rps),
+            .map_or(defaults.rate_limit.submit_ip_rps, i64_to_u32_clamped),
         submit_ip_burst: config
             .get::<i64>("rate_limit.submit_ip_burst")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.submit_ip_burst),
+            .map_or(defaults.rate_limit.submit_ip_burst, i64_to_u32_clamped),
         submit_key_rps: config
             .get::<i64>("rate_limit.submit_key_rps")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.submit_key_rps),
+            .map_or(defaults.rate_limit.submit_key_rps, i64_to_u32_clamped),
         submit_key_burst: config
             .get::<i64>("rate_limit.submit_key_burst")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.submit_key_burst),
+            .map_or(defaults.rate_limit.submit_key_burst, i64_to_u32_clamped),
         fetch_ip_rps: config
             .get::<i64>("rate_limit.fetch_ip_rps")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.fetch_ip_rps),
+            .map_or(defaults.rate_limit.fetch_ip_rps, i64_to_u32_clamped),
         fetch_ip_burst: config
             .get::<i64>("rate_limit.fetch_ip_burst")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.fetch_ip_burst),
+            .map_or(defaults.rate_limit.fetch_ip_burst, i64_to_u32_clamped),
         fetch_key_rps: config
             .get::<i64>("rate_limit.fetch_key_rps")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.fetch_key_rps),
+            .map_or(defaults.rate_limit.fetch_key_rps, i64_to_u32_clamped),
         fetch_key_burst: config
             .get::<i64>("rate_limit.fetch_key_burst")
-            .map(i64_to_u32_clamped)
-            .unwrap_or(defaults.rate_limit.fetch_key_burst),
+            .map_or(defaults.rate_limit.fetch_key_burst, i64_to_u32_clamped),
     };
 
     if let Some(serve) = serve_args {

--- a/crates/ember-message/src/lib.rs
+++ b/crates/ember-message/src/lib.rs
@@ -27,16 +27,14 @@ pub const HOUR_SECS: u64 = 60 * 60;
 pub fn now_hours() -> u32 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| (d.as_secs() / HOUR_SECS) as u32)
-        .unwrap_or(0)
+        .map_or(0, |d| (d.as_secs() / HOUR_SECS) as u32)
 }
 
 /// Get current time in seconds since Unix epoch
 pub fn now_secs() -> u64 {
     std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+        .map_or(0, |d| d.as_secs())
 }
 
 pub use tombstone::{


### PR DESCRIPTION
## Summary

- Add `ratatui-macros ^0.6` workspace dependency (compatible with ratatui 0.29)
- Replace all 6 `Layout::split()` + `chunks[N]` index patterns in `ui.rs` with `vertical!`/`horizontal!` macro destructuring
- Remove unused `Direction` import

Closes #170

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors TUI layout to use `ratatui-macros` for clearer, index-free layout code with no UI behavior changes. Also fixes Rust 1.95 clippy lints by switching to `map_or` in `ember-message` and node config.

- **Refactors**
  - Replaced six `Layout::split` + `chunks[N]` patterns with `vertical!`/`horizontal!` destructuring in `apps/client/src/tui/ui.rs` (main layout, add contact, my identity, add upstream, upstreams list).
  - Removed unused `Direction` import.
  - Switched `map().unwrap_or()` to `map_or()` in `crates/ember-message` time helpers.
  - Switched `map().unwrap_or()` to `map_or()` across config extraction in `apps/node/src/config.rs` (Rust 1.95 clippy).

- **Dependencies**
  - Added `ratatui-macros ^0.6` to the workspace and `apps/client`.
  - Pinned to `^0.6` for compatibility with `ratatui 0.29`; `0.7` depends on `ratatui-core` and causes `Rect` type mismatches.

<sup>Written for commit ff111a0e4153b07cb80a4be9f50cd6b06e3e819f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workspace dependencies to include TUI framework enhancements.

* **Refactor**
  * Improved internal UI layout code structure for better readability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->